### PR TITLE
feat: add XML extractor

### DIFF
--- a/utils/parser.py
+++ b/utils/parser.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Optional
+from pathlib import Path
+from typing import Optional, Union
 
 import fitz
 
@@ -17,6 +18,7 @@ from .pdf_extractor import (
     ParsedPDF,
     Section,
 )
+from .xml_extractor import XMLExtractor, ParsedXML
 
 
 class PDFExtractor:
@@ -103,7 +105,14 @@ class PDFExtractor:
         return parsed
 
 
-def parse_document(path: str) -> ParsedPDF:
-    """Convenience wrapper returning :class:`ParsedPDF` for *path*."""
-    extractor = PDFExtractor()
+ParsedDocument = Union[ParsedPDF, ParsedXML]
+
+
+def parse_document(path: str) -> ParsedDocument:
+    """Return a parsed representation for *path* regardless of format."""
+    ext = Path(path).suffix.lower()
+    if ext == ".pdf":
+        extractor = PDFExtractor()
+        return extractor.extract(path)
+    extractor = XMLExtractor()
     return extractor.extract(path)

--- a/utils/xml_extractor/__init__.py
+++ b/utils/xml_extractor/__init__.py
@@ -1,0 +1,6 @@
+"""XML parsing utilities."""
+
+from .xml_extractor import XMLExtractor
+from .schema import ParsedXML, Section
+
+__all__ = ["XMLExtractor", "ParsedXML", "Section"]

--- a/utils/xml_extractor/accession_extractor.py
+++ b/utils/xml_extractor/accession_extractor.py
@@ -1,0 +1,20 @@
+"""Extract accession identifiers from text."""
+
+from __future__ import annotations
+
+import re
+from typing import List
+
+
+class AccessionExtractor:
+    """Find common accession identifiers such as GSE, PMID, and PDB."""
+
+    GSE = re.compile(r"GSE\d+", re.IGNORECASE)
+    PMID = re.compile(r"PMID\d+", re.IGNORECASE)
+    PDB = re.compile(r"PDB\w+", re.IGNORECASE)
+
+    def extract(self, text: str) -> List[str]:
+        ids = set()
+        for pattern in (self.GSE, self.PMID, self.PDB):
+            ids.update(match.group(0).upper() for match in pattern.finditer(text))
+        return sorted(ids)

--- a/utils/xml_extractor/crossref_parser.py
+++ b/utils/xml_extractor/crossref_parser.py
@@ -1,0 +1,31 @@
+"""Parser for Crossref XML documents."""
+
+from __future__ import annotations
+
+from lxml import etree
+
+
+class CrossrefParser:
+    """Extract minimal metadata from Crossref XML."""
+
+    def _clean(self, text: str) -> str:
+        return " ".join(text.split())
+
+    def parse(self, root: etree._Element) -> dict:
+        title_nodes = root.xpath('.//title')
+        title_text = self._clean(" ".join(title_nodes[0].itertext())) if title_nodes else ""
+
+        abstract_nodes = root.xpath('.//abstract')
+        abstract_text = self._clean(" ".join(abstract_nodes[0].itertext())) if abstract_nodes else ""
+
+        doi_nodes = root.xpath('.//doi')
+        doi = doi_nodes[0].text.strip() if doi_nodes and doi_nodes[0].text else None
+
+        data = {
+            "title": {"text": title_text, "pages": []},
+            "abstract": {"text": abstract_text, "pages": []} if abstract_text else None,
+            "body": [],
+            "references": [],
+            "doi": doi,
+        }
+        return data

--- a/utils/xml_extractor/error_collector.py
+++ b/utils/xml_extractor/error_collector.py
@@ -1,0 +1,16 @@
+"""Collect errors during XML parsing."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Dict, List
+
+
+class XMLErrorCollector:
+    """Simple error accumulator."""
+
+    def __init__(self) -> None:
+        self.errors: Dict[str, List[str]] = defaultdict(list)
+
+    def add(self, stage: str, exc: Exception) -> None:
+        self.errors[stage].append(str(exc))

--- a/utils/xml_extractor/format_detector.py
+++ b/utils/xml_extractor/format_detector.py
@@ -1,0 +1,19 @@
+"""Detect the format of XML documents."""
+
+from __future__ import annotations
+
+from lxml import etree
+
+
+class XMLFormatDetector:
+    """Classify XML documents by root tag and namespace."""
+
+    def detect(self, root: etree._Element) -> str:
+        tag = etree.QName(root).localname.lower()
+        if tag == "collection":
+            return "bioc"
+        if tag == "doi_batch":
+            return "crossref"
+        if tag == "article":
+            return "jats"
+        return "unknown"

--- a/utils/xml_extractor/jats_parser.py
+++ b/utils/xml_extractor/jats_parser.py
@@ -1,0 +1,52 @@
+"""Parser for JATS XML documents."""
+
+from __future__ import annotations
+
+from lxml import etree
+
+from .reference_builder import ReferenceBuilder
+from .schema import Section
+
+
+class JATSParser:
+    """Extract structured content from JATS articles."""
+
+    def __init__(self) -> None:
+        self.references = ReferenceBuilder()
+
+    def _clean(self, text: str) -> str:
+        return " ".join(text.split())
+
+    def parse(self, root: etree._Element) -> dict:
+        def text_or_empty(xpath: str) -> str:
+            nodes = root.xpath(xpath)
+            if not nodes:
+                return ""
+            text = " ".join(" ".join(n.itertext()) for n in nodes)
+            return self._clean(text)
+
+        title_text = text_or_empty('.//article-title')
+        if not title_text:
+            title_text = text_or_empty('.//title-group/article-title')
+
+        abstract_text = text_or_empty('.//abstract')
+
+        body_paras = [
+            Section(text=self._clean(" ".join(p.itertext())), pages=[])
+            for p in root.xpath('.//body//p')
+        ]
+
+        ref_texts = self.references.build(root.xpath('.//ref-list//ref'))
+        refs = [Section(text=txt, pages=[]) for txt in ref_texts]
+
+        doi_nodes = root.xpath(".//article-id[@pub-id-type='doi']/text()")
+        doi = doi_nodes[0].strip() if doi_nodes else None
+
+        data = {
+            "title": {"text": title_text, "pages": []},
+            "abstract": {"text": abstract_text, "pages": []} if abstract_text else None,
+            "body": [s.dict() for s in body_paras],
+            "references": [s.dict() for s in refs],
+            "doi": doi,
+        }
+        return data

--- a/utils/xml_extractor/layout_validator.py
+++ b/utils/xml_extractor/layout_validator.py
@@ -1,0 +1,13 @@
+"""Basic validation for parsed XML documents."""
+
+from __future__ import annotations
+
+from .schema import ParsedXML
+
+
+class LayoutValidator:
+    """Perform minimal checks on parsed data."""
+
+    def validate(self, parsed: ParsedXML) -> None:
+        if not parsed.title.text:
+            raise ValueError("title is required")

--- a/utils/xml_extractor/reference_builder.py
+++ b/utils/xml_extractor/reference_builder.py
@@ -1,0 +1,18 @@
+"""Build reference strings from XML reference elements."""
+
+from __future__ import annotations
+
+from lxml import etree
+
+
+class ReferenceBuilder:
+    """Combine nested XML reference tags into strings."""
+
+    def build(self, ref_elements: list[etree._Element]) -> list[str]:
+        refs: list[str] = []
+        for ref in ref_elements:
+            text = " ".join(ref.itertext())
+            text = " ".join(text.split())
+            if text:
+                refs.append(text)
+        return refs

--- a/utils/xml_extractor/schema.py
+++ b/utils/xml_extractor/schema.py
@@ -1,0 +1,32 @@
+"""Pydantic models for parsed XML structures."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class Section(BaseModel):
+    """A text block and the source it originates from."""
+
+    text: str
+    pages: List[int] = Field(default_factory=list)
+
+
+class ParsedXML(BaseModel):
+    """Representation of a parsed XML document."""
+
+    title: Section
+    abstract: Optional[Section] = None
+    body: List[Section] = Field(default_factory=list)
+    references: List[Section] = Field(default_factory=list)
+    doi: Optional[str] = None
+    accessions: List[str] = Field(default_factory=list)
+
+
+class SchemaEncoder:
+    """Convert dictionaries into :class:`ParsedXML` objects."""
+
+    def encode(self, data: dict) -> ParsedXML:
+        return ParsedXML(**data)

--- a/utils/xml_extractor/xml_extractor.py
+++ b/utils/xml_extractor/xml_extractor.py
@@ -1,0 +1,66 @@
+"""High level interface for parsing XML documents."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from lxml import etree
+
+from .accession_extractor import AccessionExtractor
+from .crossref_parser import CrossrefParser
+from .error_collector import XMLErrorCollector
+from .format_detector import XMLFormatDetector
+from .jats_parser import JATSParser
+from .layout_validator import LayoutValidator
+from .schema import ParsedXML, SchemaEncoder
+
+
+class XMLExtractor:
+    """Parse XML documents into structured data."""
+
+    def __init__(self) -> None:
+        self.detector = XMLFormatDetector()
+        self.jats = JATSParser()
+        self.crossref = CrossrefParser()
+        self.accessions = AccessionExtractor()
+        self.validator = LayoutValidator()
+        self.encoder = SchemaEncoder()
+        self.errors = XMLErrorCollector()
+
+    def extract(self, xml_path: str) -> ParsedXML:
+        try:
+            tree = etree.parse(xml_path)
+            root = tree.getroot()
+        except Exception as exc:
+            self.errors.add("parse_xml", exc)
+            raise
+
+        fmt = self.detector.detect(root)
+        parser_map: Dict[str, object] = {
+            "jats": self.jats,
+            "crossref": self.crossref,
+        }
+        parser = parser_map.get(fmt, self.jats)
+        try:
+            data = parser.parse(root)
+        except Exception as exc:
+            self.errors.add("parse_content", exc)
+            data = {
+                "title": {"text": "", "pages": []},
+                "abstract": None,
+                "body": [],
+                "references": [],
+                "doi": None,
+            }
+
+        text_blocks = [data["title"]["text"]]
+        if data.get("abstract"):
+            text_blocks.append(data["abstract"]["text"])
+        text_blocks.extend(section["text"] for section in data.get("body", []))
+        text_blocks.extend(section["text"] for section in data.get("references", []))
+        all_text = " ".join(text_blocks)
+        data["accessions"] = self.accessions.extract(all_text)
+
+        parsed = self.encoder.encode(data)
+        self.validator.validate(parsed)
+        return parsed


### PR DESCRIPTION
## Summary
- add XMLExtractor with format detection and accession parsing
- support JATS and Crossref XML parsing
- allow parser to handle both PDF and XML inputs

## Testing
- `python -m pytest`
- `ruff check`


------
https://chatgpt.com/codex/tasks/task_e_688c62a4c190832fae3eb94b27e396fc