### PR TITLE
feat: add DOI recognizer

### DIFF
--- a/utils/doi_recognizer/__init__.py
+++ b/utils/doi_recognizer/__init__.py
@@ -1,0 +1,3 @@
+from .doi_recognizer import DOIRecognizer, StructuredID
+
+__all__ = ["DOIRecognizer", "StructuredID"]

--- a/utils/doi_recognizer/doi_recognizer.py
+++ b/utils/doi_recognizer/doi_recognizer.py
@@ -1,0 +1,65 @@
+"""High level identifier recognition utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+from .regex_extractor import RegexExtractor
+from .fuzzy_matcher import FuzzyMatcher
+from .normalizer import DOINormalizer, AccessionNormalizer
+from .type_classifier import IDTypeClassifier
+from .semantic_locator import SemanticZoneLocator
+from .remote_validator import RemoteValidator
+
+
+@dataclass
+class StructuredID:
+    """A structured representation of an identifier."""
+
+    id_type: str
+    raw: str
+    normalized: str
+    page: Optional[int] = None
+    section: Optional[str] = None
+
+
+class DOIRecognizer:
+    """Recognize and normalise various document identifiers."""
+
+    def __init__(self) -> None:
+        self.regex = RegexExtractor()
+        self.fuzzy = FuzzyMatcher()
+        self.doi_norm = DOINormalizer()
+        self.acc_norm = AccessionNormalizer()
+        self.classifier = IDTypeClassifier()
+        self.locator = SemanticZoneLocator()
+        self.validator = RemoteValidator()
+
+    def recognize(self, text: str, meta: Optional[dict] = None) -> List[StructuredID]:
+        """Return structured identifiers found in *text*."""
+
+        meta = meta or {}
+        matches = self.regex.extract(text)
+        if not matches:
+            matches = self.fuzzy.extract(text)
+
+        ids: List[StructuredID] = []
+        for match in matches:
+            normalized = (
+                self.doi_norm.normalize(match.value)
+                if match.id_type == "doi"
+                else self.acc_norm.normalize(match.value, match.id_type)
+            )
+            ids.append(
+                StructuredID(
+                    id_type=match.id_type,
+                    raw=match.value,
+                    normalized=normalized,
+                    page=meta.get("page"),
+                    section=meta.get("section"),
+                )
+            )
+
+        ids = self.locator.filter(ids, meta)
+        return [i for i in ids if self.validator.validate(i.normalized, i.id_type)]

--- a/utils/doi_recognizer/fuzzy_matcher.py
+++ b/utils/doi_recognizer/fuzzy_matcher.py
@@ -1,0 +1,26 @@
+"""Fuzzy matching helpers for broken identifiers."""
+
+from __future__ import annotations
+
+import re
+from typing import List
+
+from .regex_extractor import RegexMatch
+
+
+class FuzzyMatcher:
+    """Attempt to recover identifiers split by whitespace or newlines."""
+
+    DOI_FUZZY = re.compile(
+        r"10\s*[.](?:\s*\d){4,9}\s*/\s*[-._;()/:A-Z0-9]+",
+        re.I | re.DOTALL,
+    )
+
+    def extract(self, text: str) -> List[RegexMatch]:
+        matches: List[RegexMatch] = []
+        for match in self.DOI_FUZZY.finditer(text):
+            cleaned = re.sub(r"\s+", "", match.group(0))
+            matches.append(
+                RegexMatch("doi", cleaned, match.start(), match.end())
+            )
+        return matches

--- a/utils/doi_recognizer/normalizer.py
+++ b/utils/doi_recognizer/normalizer.py
@@ -1,0 +1,25 @@
+"""Normalization helpers for identifiers."""
+
+from __future__ import annotations
+
+import re
+
+
+class DOINormalizer:
+    """Normalize raw DOI strings."""
+
+    def normalize(self, doi: str) -> str:
+        doi = doi.strip()
+        if doi.lower().startswith("doi:"):
+            doi = doi.split(":", 1)[1]
+        return f"doi:{doi.lower()}"
+
+
+class AccessionNormalizer:
+    """Normalize other identifier types such as PMID and GSE."""
+
+    def normalize(self, value: str, id_type: str) -> str:
+        clean = re.sub(r"[^0-9A-Za-z]", "", value)
+        if id_type == "pmcid" and not clean.upper().startswith("PMC"):
+            clean = f"PMC{clean}"
+        return f"{id_type}:{clean.lower()}"

--- a/utils/doi_recognizer/regex_extractor.py
+++ b/utils/doi_recognizer/regex_extractor.py
@@ -1,0 +1,44 @@
+"""Regular expression based ID extractor."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class RegexMatch:
+    """A raw regex match for an identifier."""
+
+    id_type: str
+    value: str
+    start: int
+    end: int
+
+
+class RegexExtractor:
+    """Extract accession-like identifiers using regex patterns."""
+
+    PATTERNS = {
+        "doi": re.compile(r"10\.\d{4,9}/[-._;()/:A-Z0-9]+", re.I),
+        "pmid": re.compile(r"PMID[:\s]*\d+", re.I),
+        "pmcid": re.compile(r"PMC(?:ID)?[:\s]*\d+", re.I),
+        "gse": re.compile(r"GSE\d{3,6}", re.I),
+        "srr": re.compile(r"SRR\d{3,6}", re.I),
+        "pdb": re.compile(r"PDB[\s-]?ID[:\s]*[0-9A-Z]{4}", re.I),
+    }
+
+    def extract(self, text: str) -> List[RegexMatch]:
+        matches: List[RegexMatch] = []
+        for id_type, pattern in self.PATTERNS.items():
+            for match in pattern.finditer(text):
+                matches.append(
+                    RegexMatch(
+                        id_type=id_type,
+                        value=match.group(0),
+                        start=match.start(),
+                        end=match.end(),
+                    )
+                )
+        return matches

--- a/utils/doi_recognizer/remote_validator.py
+++ b/utils/doi_recognizer/remote_validator.py
@@ -1,0 +1,11 @@
+"""Optional remote validation for identifiers."""
+
+from __future__ import annotations
+
+class RemoteValidator:
+    """Validate identifiers using remote APIs (placeholder)."""
+
+    def validate(self, id_value: str, id_type: str) -> bool:
+        # In production this would query Crossref or Entrez.
+        # Here we simply accept all identifiers.
+        return True

--- a/utils/doi_recognizer/semantic_locator.py
+++ b/utils/doi_recognizer/semantic_locator.py
@@ -1,0 +1,21 @@
+"""Locate semantic zones to improve precision."""
+
+from __future__ import annotations
+
+from typing import Iterable, List, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - only for type checkers
+    from .doi_recognizer import StructuredID
+
+
+class SemanticZoneLocator:
+    """Filter identifiers based on contextual metadata."""
+
+    def filter(self, ids: Iterable["StructuredID"], meta: dict) -> List["StructuredID"]:
+        section = meta.get("section")
+        if not section:
+            return list(ids)
+        allowed = {"abstract", "body", "methods", "references"}
+        if section.lower() in allowed:
+            return list(ids)
+        return []

--- a/utils/doi_recognizer/type_classifier.py
+++ b/utils/doi_recognizer/type_classifier.py
@@ -1,0 +1,25 @@
+"""Fallback identifier type classification."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+
+class IDTypeClassifier:
+    """Guess identifier types based on simple heuristics."""
+
+    def classify(self, value: str) -> Optional[str]:
+        value_upper = value.upper()
+        if value_upper.startswith("10."):
+            return "doi"
+        if value_upper.startswith("PMCID") or value_upper.startswith("PMC"):
+            return "pmcid"
+        if value_upper.startswith("PMID"):
+            return "pmid"
+        if value_upper.startswith("GSE"):
+            return "gse"
+        if value_upper.startswith("SRR"):
+            return "srr"
+        if value_upper.startswith("PDB"):
+            return "pdb"
+        return None

--- a/utils/parser.py
+++ b/utils/parser.py
@@ -8,7 +8,6 @@ from typing import Optional, Union
 import fitz
 
 from .pdf_extractor import (
-    DOIExtractor,
     LayoutValidator,
     PageSegmenter,
     ParagraphRestorer,
@@ -19,13 +18,14 @@ from .pdf_extractor import (
     Section,
 )
 from .xml_extractor import XMLExtractor, ParsedXML
+from .doi_recognizer import DOIRecognizer
 
 
 class PDFExtractor:
     """High level interface for parsing PDFs into structured data."""
 
     def __init__(self) -> None:
-        self.doi_extractor = DOIExtractor()
+        self.id_recognizer = DOIRecognizer()
         self.restorer = ParagraphRestorer()
         self.reference_splitter = ReferenceSplitter()
         self.validator = LayoutValidator()
@@ -49,7 +49,8 @@ class PDFExtractor:
                 paragraphs_with_pages.append((para, page["page"]))
 
         full_text = "\n".join(p for p, _ in paragraphs_with_pages)
-        doi = self.doi_extractor.extract(full_text)
+        ids = self.id_recognizer.recognize(full_text)
+        doi = next((i.normalized for i in ids if i.id_type == "doi"), None)
 
         title_text = (
             paragraphs_with_pages[0][0]


### PR DESCRIPTION
## Summary
- add `DOIRecognizer` module for robust identifier extraction and normalization
- integrate DOI recognizer into PDF parsing pipeline

## Testing
- `pytest`
- `ruff check utils/doi_recognizer utils/parser.py`

------
https://chatgpt.com/codex/tasks/task_e_688c63f9c648832fb2acd71718500990