### PR TITLE
Add accession matcher for biological identifiers

### DIFF
--- a/utils/doi_recognizer/__init__.py
+++ b/utils/doi_recognizer/__init__.py
@@ -1,3 +1,10 @@
 from .doi_recognizer import DOIRecognizer, StructuredID
+from .accession_matcher import AccessionMatcher
+from .accession_schema import AccessionItem
 
-__all__ = ["DOIRecognizer", "StructuredID"]
+__all__ = [
+    "DOIRecognizer",
+    "StructuredID",
+    "AccessionMatcher",
+    "AccessionItem",
+]

--- a/utils/doi_recognizer/accession_matcher.py
+++ b/utils/doi_recognizer/accession_matcher.py
@@ -1,0 +1,55 @@
+"""High level matcher that extracts accession identifiers from text."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from .pattern_registry import PatternRegistry, PatternMatch
+from .fuzzy_resolver import FuzzyAccessionResolver
+from .context_weighter import ContextWeighter
+from .normalizer import AccessionNormalizer
+from .accession_schema import AccessionItem
+
+
+class AccessionMatcher:
+    """Extract and normalise common accession identifiers."""
+
+    def __init__(self) -> None:
+        self.registry = PatternRegistry()
+        self.fuzzy = FuzzyAccessionResolver()
+        self.context = ContextWeighter()
+        self.normalizer = AccessionNormalizer()
+
+    def match(
+        self, text: str, meta: Optional[dict] = None
+    ) -> List[AccessionItem]:
+        meta = meta or {}
+        raw_matches: List[PatternMatch] = self.registry.find(text)
+        raw_matches.extend(self.fuzzy.resolve(text))
+
+        items: List[AccessionItem] = []
+        seen = set()
+        for m in raw_matches:
+            key = (m.id_type, m.start, m.end)
+            if key in seen:
+                continue
+            seen.add(key)
+            score = self.context.weight(text, m, meta)
+            standardized = self.normalizer.normalize(m.value, m.id_type)
+            items.append(
+                AccessionItem(
+                    raw_text=m.value,
+                    standardized_id=standardized,
+                    id_type=m.id_type,
+                    score=score,
+                    source={
+                        "page": meta.get("page"),
+                        "section": meta.get("section"),
+                        "offset": m.start,
+                    },
+                )
+            )
+        return items
+
+
+__all__ = ["AccessionMatcher"]

--- a/utils/doi_recognizer/accession_schema.py
+++ b/utils/doi_recognizer/accession_schema.py
@@ -1,0 +1,20 @@
+"""Schema definitions for accession matching results."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Dict, Any
+
+
+@dataclass
+class AccessionItem:
+    """Structured output for accession identifiers."""
+
+    raw_text: str
+    standardized_id: str
+    id_type: str
+    score: float
+    source: Dict[str, Optional[Any]]
+
+
+__all__ = ["AccessionItem"]

--- a/utils/doi_recognizer/context_weighter.py
+++ b/utils/doi_recognizer/context_weighter.py
@@ -1,0 +1,32 @@
+"""Heuristic context based scoring for accession identifiers."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from .pattern_registry import PatternMatch
+
+
+class ContextWeighter:
+    """Assign a confidence score based on local textual context."""
+
+    KEYWORDS = {"data", "dataset", "accession", "geo", "sra"}
+    PRIORITY_SECTIONS = {"methods", "data availability"}
+
+    def weight(
+        self, text: str, match: PatternMatch, meta: Optional[dict] = None
+    ) -> float:
+        meta = meta or {}
+        score = 0.5
+        start = max(0, match.start - 50)
+        end = match.end + 50
+        window = text[start:end].lower()
+        if any(k in window for k in self.KEYWORDS):
+            score += 0.3
+        section = str(meta.get("section", "")).lower()
+        if section in self.PRIORITY_SECTIONS:
+            score += 0.2
+        return min(score, 1.0)
+
+
+__all__ = ["ContextWeighter"]

--- a/utils/doi_recognizer/fuzzy_resolver.py
+++ b/utils/doi_recognizer/fuzzy_resolver.py
@@ -1,0 +1,50 @@
+"""Fuzzy matching for imperfect accession identifiers."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from typing import List
+
+from fuzzywuzzy import fuzz
+
+from .pattern_registry import PatternMatch
+
+
+class FuzzyAccessionResolver:
+    """Resolve malformed or partial accession identifiers using fuzzy logic."""
+
+    def __init__(self) -> None:
+        self.prefixes = {
+            "GEO": "GSE",
+            "SRA": "SRR",
+            "EGA": "EGAD",
+            "ENA": "ER",
+        }
+        self.candidate = re.compile(
+            r"([A-Za-z]{2,5})[\s-]*([0-9]{3,13})",
+            re.I,
+        )
+
+    def resolve(self, text: str) -> List[PatternMatch]:
+        norm = unicodedata.normalize("NFKC", text)
+        matches: List[PatternMatch] = []
+        for m in self.candidate.finditer(norm):
+            prefix = m.group(1).upper()
+            digits = m.group(2)
+            for id_type, expected in self.prefixes.items():
+                if fuzz.ratio(prefix, expected) >= 80:
+                    value = expected + digits
+                    matches.append(
+                        PatternMatch(
+                            id_type=id_type,
+                            value=value,
+                            start=m.start(),
+                            end=m.end(),
+                        )
+                    )
+                    break
+        return matches
+
+
+__all__ = ["FuzzyAccessionResolver"]

--- a/utils/doi_recognizer/pattern_registry.py
+++ b/utils/doi_recognizer/pattern_registry.py
@@ -1,0 +1,46 @@
+"""Regular expression patterns for accession identifiers."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Dict, List
+
+
+@dataclass
+class PatternMatch:
+    """Raw regex match for an accession identifier."""
+
+    id_type: str
+    value: str
+    start: int
+    end: int
+
+
+class PatternRegistry:
+    """Registry holding regex patterns for common accession identifiers."""
+
+    PATTERNS: Dict[str, re.Pattern] = {
+        "GEO": re.compile(r"GSE\d{3,7}", re.I),
+        "SRA": re.compile(r"S(?:RR|RP|RS|RX)\d{5,9}", re.I),
+        "PDB": re.compile(r"(?:PDB[:\s-]*)?[0-9A-Z]{4}", re.I),
+        "EGA": re.compile(r"EGA[DS]\d{11,13}", re.I),
+        "ENA": re.compile(r"ER[RXDS]\d{6,10}", re.I),
+    }
+
+    def find(self, text: str) -> List[PatternMatch]:
+        matches: List[PatternMatch] = []
+        for id_type, pattern in self.PATTERNS.items():
+            for m in pattern.finditer(text):
+                matches.append(
+                    PatternMatch(
+                        id_type=id_type,
+                        value=m.group(0),
+                        start=m.start(),
+                        end=m.end(),
+                    )
+                )
+        return matches
+
+
+__all__ = ["PatternRegistry", "PatternMatch"]


### PR DESCRIPTION
## Summary
- add AccessionMatcher pipeline with regex, fuzzy repair, context weighting and normalization
- expose AccessionItem schema and helper modules

## Testing
- `python -m pytest`
- `flake8 utils/doi_recognizer/__init__.py utils/doi_recognizer/normalizer.py utils/doi_recognizer/accession_matcher.py utils/doi_recognizer/accession_schema.py utils/doi_recognizer/context_weighter.py utils/doi_recognizer/fuzzy_resolver.py utils/doi_recognizer/pattern_registry.py`


------
https://chatgpt.com/codex/tasks/task_e_688c65bf7aac832fa1d1d9713ab9608f