### PR TITLE
feat: add unified file parser with accession matching

### DIFF
--- a/utils/parsed_doc.py
+++ b/utils/parsed_doc.py
@@ -1,0 +1,26 @@
+"""Unified schema for parsed documents."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+from .doi_recognizer import AccessionItem
+
+
+class ParsedDoc(BaseModel):
+    """Normalised representation of a parsed PDF or XML document."""
+
+    doc_id: str
+    source_type: Literal["pdf", "xml"]
+    title: str
+    abstract: str = ""
+    body: str = ""
+    references: List[str] = Field(default_factory=list)
+    doi: Optional[str] = None
+    accessions: List[AccessionItem] = Field(default_factory=list)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+__all__ = ["ParsedDoc"]

--- a/utils/pdf_extractor/schema.py
+++ b/utils/pdf_extractor/schema.py
@@ -6,6 +6,8 @@ from typing import List, Optional
 
 from pydantic import BaseModel, Field
 
+from ..doi_recognizer import AccessionItem
+
 
 class Section(BaseModel):
     """A text block and the pages it originates from."""
@@ -22,6 +24,7 @@ class ParsedPDF(BaseModel):
     body: List[Section] = Field(default_factory=list)
     references: List[Section] = Field(default_factory=list)
     doi: Optional[str] = None
+    accessions: List[AccessionItem] = Field(default_factory=list)
 
 
 class SchemaEncoder:

--- a/utils/xml_extractor/schema.py
+++ b/utils/xml_extractor/schema.py
@@ -6,6 +6,8 @@ from typing import List, Optional
 
 from pydantic import BaseModel, Field
 
+from ..doi_recognizer import AccessionItem
+
 
 class Section(BaseModel):
     """A text block and the source it originates from."""
@@ -22,7 +24,7 @@ class ParsedXML(BaseModel):
     body: List[Section] = Field(default_factory=list)
     references: List[Section] = Field(default_factory=list)
     doi: Optional[str] = None
-    accessions: List[str] = Field(default_factory=list)
+    accessions: List[AccessionItem] = Field(default_factory=list)
 
 
 class SchemaEncoder:


### PR DESCRIPTION
## Summary
- add ParsedDoc model to unify parsed PDF and XML outputs
- integrate AccessionMatcher into PDF and XML extractors
- introduce FileParser dispatcher returning ParsedDoc

## Testing
- `python -m pytest`
- `flake8 utils/parser.py utils/parsed_doc.py utils/pdf_extractor/schema.py utils/xml_extractor/schema.py utils/xml_extractor/xml_extractor.py`


------
https://chatgpt.com/codex/tasks/task_e_688c6863d480832f83411975cff1a391