### PR TITLE
feat: add sliding window context builder

### DIFF
--- a/tests/test_context_builder.py
+++ b/tests/test_context_builder.py
@@ -1,0 +1,25 @@
+import os
+import sys
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+)
+
+from utils.context_builder import build_context  # noqa: E402
+from utils.parsed_doc import ParsedDoc  # noqa: E402
+
+
+def test_build_context_basic():
+    doc = ParsedDoc(
+        doc_id="DOC1",
+        source_type="pdf",
+        title="Sample Title",
+        abstract="This is the abstract. It has two sentences.",
+        body="Paragraph one. Still first paragraph.\nParagraph two is here.",
+    )
+    contexts = build_context(doc, max_tokens=20, stride=5)
+    assert contexts, "No contexts returned"
+    for ctx in contexts:
+        assert ctx.doc_id == "DOC1"
+        assert ctx.token_count <= 20
+        assert ctx.source.section in {"title", "abstract", "body"}

--- a/utils/context_builder.py
+++ b/utils/context_builder.py
@@ -1,6 +1,0 @@
-"""L2: Build contextual windows for downstream tasks."""
-
-
-def build_context(entries: list[str]) -> list[str]:
-    """Placeholder context builder."""
-    return entries

--- a/utils/context_builder/__init__.py
+++ b/utils/context_builder/__init__.py
@@ -1,0 +1,20 @@
+"""Context builder package providing sliding window functionality."""
+
+from __future__ import annotations
+
+from typing import List
+
+from ..parsed_doc import ParsedDoc
+from .schema import ContextUnit
+from .sliding_window import SlidingWindowContext
+
+
+def build_context(
+    parsed_doc: ParsedDoc, max_tokens: int = 512, stride: int = 128
+) -> List[ContextUnit]:
+    """Build context units from a parsed document using a sliding window."""
+    builder = SlidingWindowContext(max_tokens=max_tokens, stride=stride)
+    return builder.build(parsed_doc)
+
+
+__all__ = ["build_context", "ContextUnit", "SlidingWindowContext"]

--- a/utils/context_builder/context_formatter.py
+++ b/utils/context_builder/context_formatter.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import uuid
+
+from .schema import ContextUnit, SourceInfo
+
+
+def format_context(
+    doc_id: str,
+    text: str,
+    section: str,
+    start_sentence_idx: int,
+    end_sentence_idx: int,
+    original_paragraph_id: int,
+    token_count: int,
+    importance_score: float,
+) -> ContextUnit:
+    """Create a :class:`ContextUnit` with standard metadata."""
+
+    context_id = f"ctx_{uuid.uuid4().hex[:8]}"
+    source = SourceInfo(
+        section=section,
+        start_sentence_idx=start_sentence_idx,
+        end_sentence_idx=end_sentence_idx,
+        original_paragraph_id=original_paragraph_id,
+    )
+    return ContextUnit(
+        context_id=context_id,
+        doc_id=doc_id,
+        text=text,
+        source=source,
+        token_count=token_count,
+        importance_score=importance_score,
+    )
+
+
+__all__ = ["format_context"]

--- a/utils/context_builder/context_weighter.py
+++ b/utils/context_builder/context_weighter.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+
+def positional_weight(start_idx: int, total_sentences: int) -> float:
+    """Simple position-based weighting.
+
+    Earlier sentences receive higher scores.
+    """
+    if total_sentences == 0:
+        return 0.0
+    return 1.0 - (start_idx / total_sentences)
+
+
+def compute_importance(
+    start_idx: int, total_sentences: int, section: str
+) -> float:
+    """Combine positional weight with section heuristics."""
+    weight = positional_weight(start_idx, total_sentences)
+    if section == "title":
+        weight += 0.5
+    elif section == "abstract":
+        weight += 0.25
+    return min(weight, 1.0)
+
+
+__all__ = ["compute_importance"]

--- a/utils/context_builder/schema.py
+++ b/utils/context_builder/schema.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class SourceInfo(BaseModel):
+    """Metadata describing the origin of a context unit."""
+
+    section: str
+    start_sentence_idx: int = Field(..., ge=0)
+    end_sentence_idx: int = Field(..., ge=0)
+    original_paragraph_id: int = Field(..., ge=0)
+
+
+class ContextUnit(BaseModel):
+    """Standard structure for a context unit passed to the LLM."""
+
+    context_id: str
+    doc_id: str
+    text: str
+    source: SourceInfo
+    token_count: int
+    importance_score: float = 0.0
+
+
+__all__ = ["ContextUnit", "SourceInfo"]

--- a/utils/context_builder/sliding_window.py
+++ b/utils/context_builder/sliding_window.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import re
+from typing import List, Tuple
+
+from ..parsed_doc import ParsedDoc
+from .context_formatter import format_context
+from .context_weighter import compute_importance
+from .tokenizer_wrapper import TokenizerWrapper
+from .validator import validate_contexts
+from .schema import ContextUnit
+
+
+SentenceInfo = Tuple[str, int, int, str]
+# (section, paragraph_id, sentence_idx, text)
+
+
+class SlidingWindowContext:
+    """Build context units using a sliding window over document sentences."""
+
+    def __init__(
+        self,
+        max_tokens: int = 512,
+        stride: int = 128,
+        tokenizer: TokenizerWrapper | None = None,
+    ) -> None:
+        self.max_tokens = max_tokens
+        self.stride = stride
+        self.tokenizer = tokenizer or TokenizerWrapper()
+
+    # ------------------------------------------------------------------
+    # Sentence preparation
+    # ------------------------------------------------------------------
+    def _split_sentences(self, text: str) -> List[str]:
+        pattern = r"(?<=[.!?])\s+"
+        return [s.strip() for s in re.split(pattern, text) if s.strip()]
+
+    def _prepare_sentences(self, doc: ParsedDoc) -> List[SentenceInfo]:
+        sentences: List[SentenceInfo] = []
+        # Title as single sentence
+        if doc.title:
+            sentences.append(("title", 0, 0, doc.title.strip()))
+        # Abstract
+        if doc.abstract:
+            idx = 0
+            for pid, para in enumerate(
+                filter(None, [p.strip() for p in doc.abstract.split("\n")])
+            ):
+                for sent in self._split_sentences(para):
+                    sentences.append(("abstract", pid, idx, sent))
+                    idx += 1
+        # Body
+        if doc.body:
+            idx = 0
+            for pid, para in enumerate(
+                filter(None, [p.strip() for p in doc.body.split("\n")])
+            ):
+                for sent in self._split_sentences(para):
+                    sentences.append(("body", pid, idx, sent))
+                    idx += 1
+        return sentences
+
+    # ------------------------------------------------------------------
+    # Window generation
+    # ------------------------------------------------------------------
+    def _generate_windows(
+        self, sentences: List[SentenceInfo]
+    ) -> List[Tuple[int, int, int]]:
+        token_counts = [
+            self.tokenizer.count_tokens(s[3]) for s in sentences
+        ]
+        windows: List[Tuple[int, int, int]] = []
+        start = 0
+        n = len(sentences)
+        while start < n:
+            end = start
+            total = 0
+            while end < n and total + token_counts[end] <= self.max_tokens:
+                total += token_counts[end]
+                end += 1
+            if start == end:
+                end += 1
+                total = token_counts[start]
+            windows.append((start, end, total))
+            if end >= n:
+                break
+            # compute new start to keep ``stride`` tokens overlap
+            overlap = self.stride
+            back = end
+            kept = 0
+            while back > start and kept < overlap:
+                back -= 1
+                kept += token_counts[back]
+            start = back
+        return windows
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def build(self, doc: ParsedDoc) -> List[ContextUnit]:
+        sentences = self._prepare_sentences(doc)
+        total_sentences = len(sentences)
+        windows = self._generate_windows(sentences)
+        contexts: List[ContextUnit] = []
+        for start, end, token_count in windows:
+            snippet = sentences[start:end]
+            text = " ".join(s[3] for s in snippet)
+            section = snippet[0][0]
+            start_sentence_idx = snippet[0][2]
+            end_sentence_idx = snippet[-1][2]
+            original_paragraph_id = snippet[0][1]
+            importance = compute_importance(
+                start_sentence_idx, total_sentences, section
+            )
+            ctx = format_context(
+                doc_id=doc.doc_id,
+                text=text,
+                section=section,
+                start_sentence_idx=start_sentence_idx,
+                end_sentence_idx=end_sentence_idx,
+                original_paragraph_id=original_paragraph_id,
+                token_count=token_count,
+                importance_score=importance,
+            )
+            contexts.append(ctx)
+        return validate_contexts(contexts, self.max_tokens)
+
+
+__all__ = ["SlidingWindowContext"]

--- a/utils/context_builder/tokenizer_wrapper.py
+++ b/utils/context_builder/tokenizer_wrapper.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import List
+
+from transformers import AutoTokenizer
+
+
+class TokenizerWrapper:
+    """Thin wrapper around a LLaMA tokenizer for token counting."""
+
+    def __init__(
+        self, model_name: str = "hf-internal-testing/llama-tokenizer"
+    ) -> None:
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+
+    def count_tokens(self, text: str) -> int:
+        """Return the number of tokens for ``text``."""
+        return len(self.tokenizer.encode(text, add_special_tokens=False))
+
+    def encode(self, text: str) -> List[int]:
+        """Encode ``text`` and return the token ids."""
+        return self.tokenizer.encode(text, add_special_tokens=False)
+
+
+__all__ = ["TokenizerWrapper"]

--- a/utils/context_builder/validator.py
+++ b/utils/context_builder/validator.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from .schema import ContextUnit
+
+
+def validate_contexts(
+    contexts: Iterable[ContextUnit], max_tokens: int
+) -> List[ContextUnit]:
+    """Filter invalid context units."""
+    valid: List[ContextUnit] = []
+    for ctx in contexts:
+        if not ctx.text.strip():
+            continue
+        if ctx.token_count > max_tokens:
+            continue
+        valid.append(ctx)
+    return valid
+
+
+__all__ = ["validate_contexts"]


### PR DESCRIPTION
## Summary
- implement token-aware SlidingWindowContext builder with overlap, importance scoring, and metadata
- add tokenizer wrapper, formatter, validator, and tests

## Testing
- `pytest -q`
- `flake8 utils/context_builder tests/test_context_builder.py`


------
https://chatgpt.com/codex/tasks/task_e_688c6d29d120832f9823280d29408d8b