### PR TITLE
Add prompt perturbation robustness tester

### DIFF
--- a/utils/llm_inference/__init__.py
+++ b/utils/llm_inference/__init__.py
@@ -4,9 +4,19 @@ from .output_decoder import LLMOutputDecoder, FinalPrediction, DecodingStrategy
 
 try:  # pragma: no cover - optional heavy imports
     from .llama3_inference import LLaMA3Inference, LLMResult
+    from .perturbation_tester import PromptPerturbationTester
+    from .report_schema import (
+        PerturbationReport,
+        VariantOutput,
+        ReportFormatter,
+    )
 except Exception:  # pragma: no cover - torch or other deps missing
     LLaMA3Inference = None  # type: ignore
     LLMResult = None  # type: ignore
+    PromptPerturbationTester = None  # type: ignore
+    PerturbationReport = None  # type: ignore
+    VariantOutput = None  # type: ignore
+    ReportFormatter = None  # type: ignore
 
 __all__ = [
     "LLaMA3Inference",
@@ -14,4 +24,8 @@ __all__ = [
     "LLMOutputDecoder",
     "FinalPrediction",
     "DecodingStrategy",
+    "PromptPerturbationTester",
+    "PerturbationReport",
+    "VariantOutput",
+    "ReportFormatter",
 ]

--- a/utils/llm_inference/label_comparer.py
+++ b/utils/llm_inference/label_comparer.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+"""Compare labels across perturbation runs."""
+
+from dataclasses import dataclass
+from typing import List
+
+from .llama3_inference import LLMResult
+
+
+@dataclass
+class CompareResult:
+    """Outcome of label comparison."""
+
+    match_count: int
+    mismatched_indices: List[int]
+
+
+class LabelComparer:
+    """Checks whether variant outputs align with the original label."""
+
+    def compare(
+        self,
+        original_label: str,
+        results: List[LLMResult],
+    ) -> CompareResult:
+        match_count = 0
+        mismatches: List[int] = []
+        for idx, res in enumerate(results):
+            if res.predicted_label == original_label:
+                match_count += 1
+            else:
+                mismatches.append(idx)
+        return CompareResult(
+            match_count=match_count,
+            mismatched_indices=mismatches,
+        )

--- a/utils/llm_inference/multiprompt_runner.py
+++ b/utils/llm_inference/multiprompt_runner.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+"""Execute inference across multiple prompt variants."""
+
+from typing import List
+
+from .llama3_inference import LLaMA3Inference, LLMResult
+from .output_decoder import DecodingStrategy
+
+
+class MultiPromptRunner:
+    """Runs a batch of prompts through :class:`LLaMA3Inference`."""
+
+    def __init__(self, inference: LLaMA3Inference) -> None:
+        self.inference = inference
+
+    def run(
+        self,
+        context_id: str,
+        prompt_variants: List[str],
+    ) -> List[LLMResult]:
+        """Run inference for each prompt variant and collect results."""
+        results: List[LLMResult] = []
+        for idx, prompt in enumerate(prompt_variants):
+            tokens = self.inference.tokenizer.encode(prompt)
+            generated = self.inference.engine.generate(
+                tokens, max_new_tokens=32, temperature=0.0
+            )
+            text = self.inference.tokenizer.decode(generated["tokens"])
+            prediction = self.inference.decoder.decode(
+                context_id=f"{context_id}_v{idx}",
+                text=text,
+                scores=generated["scores"],
+                strategy=DecodingStrategy.TEXT2LABEL,
+            )
+            results.append(
+                LLMResult(
+                    context_id=context_id,
+                    predicted_label=prediction.final_label,
+                    confidence=prediction.confidence,
+                    raw_output=prediction.raw_output,
+                    prompt=prompt,
+                    logits=prediction.logits,
+                    meta={
+                        "label_source": prediction.label_source,
+                        "used_strategy": prediction.used_strategy,
+                    },
+                )
+            )
+        return results

--- a/utils/llm_inference/perturbation_generator.py
+++ b/utils/llm_inference/perturbation_generator.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""Generate semantic-preserving prompt perturbations."""
+
+from dataclasses import dataclass
+from typing import List
+import random
+
+
+@dataclass
+class GeneratorConfig:
+    """Configuration for :class:`PerturbationGenerator`."""
+
+    num_variants: int = 5
+    seed: int | None = None
+
+
+class PerturbationGenerator:
+    """Create simple variations of a prompt while preserving intent."""
+
+    def __init__(self, config: GeneratorConfig | None = None) -> None:
+        self.config = config or GeneratorConfig()
+        if self.config.seed is not None:
+            random.seed(self.config.seed)
+
+    def generate(self, prompt: str) -> List[str]:
+        """Return ``num_variants`` perturbations of ``prompt``."""
+        variants: List[str] = []
+        for i in range(self.config.num_variants):
+            strategy = i % 4
+            if strategy == 0:  # add polite prefix
+                variants.append(f"Please {prompt}")
+            elif strategy == 1:  # append courtesy suffix
+                variants.append(f"{prompt}, thank you")
+            elif strategy == 2:  # insert filler words
+                variants.append(f"Um, {prompt}")
+            else:  # reorder simple clauses if possible
+                parts = prompt.split(",")
+                if len(parts) > 1:
+                    random.shuffle(parts)
+                    variants.append(",".join(p.strip() for p in parts))
+                else:
+                    variants.append(prompt)
+        return variants

--- a/utils/llm_inference/perturbation_tester.py
+++ b/utils/llm_inference/perturbation_tester.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+"""Main entry point for prompt perturbation robustness testing."""
+
+from .llama3_inference import LLaMA3Inference
+from .perturbation_generator import PerturbationGenerator, GeneratorConfig
+from .multiprompt_runner import MultiPromptRunner
+from .label_comparer import LabelComparer
+from .score_computer import ScoreComputer
+from .report_schema import (
+    PerturbationReport,
+    VariantOutput,
+)
+
+
+class PromptPerturbationTester:
+    """Run invariance checks by perturbing prompts and evaluating outputs."""
+
+    def __init__(
+        self,
+        inference: LLaMA3Inference,
+        num_variants: int = 5,
+        min_invariance_score: float = 0.9,
+        confidence_drop_threshold: float = 0.2,
+    ) -> None:
+        self.generator = PerturbationGenerator(
+            GeneratorConfig(num_variants=num_variants)
+        )
+        self.runner = MultiPromptRunner(inference)
+        self.comparer = LabelComparer()
+        self.scorer = ScoreComputer()
+        self.min_invariance_score = min_invariance_score
+        self.confidence_drop_threshold = confidence_drop_threshold
+
+    def test(
+        self,
+        context_id: str,
+        prompt: str,
+        original_label: str,
+        original_confidence: float,
+    ) -> PerturbationReport:
+        """Execute the perturbation test and return a structured report."""
+        variants = self.generator.generate(prompt)
+        results = self.runner.run(context_id, variants)
+        compare = self.comparer.compare(original_label, results)
+        score = self.scorer.compute(
+            original_confidence, original_label, results
+        )
+        variant_outputs = [
+            VariantOutput(
+                prompt_variant=variants[i],
+                label=r.predicted_label,
+                confidence=r.confidence,
+            )
+            for i, r in enumerate(results)
+        ]
+        is_consistent = (
+            score.invariance_score >= self.min_invariance_score
+            and score.avg_confidence_drop <= self.confidence_drop_threshold
+        )
+        return PerturbationReport(
+            context_id=context_id,
+            original_label=original_label,
+            perturbation_variants=len(variants),
+            match_count=compare.match_count,
+            invariance_score=score.invariance_score,
+            avg_confidence_drop=score.avg_confidence_drop,
+            variant_outputs=variant_outputs,
+            is_consistent=is_consistent,
+        )

--- a/utils/llm_inference/report_schema.py
+++ b/utils/llm_inference/report_schema.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+"""Schemas and helpers for prompt perturbation reports."""
+
+from dataclasses import dataclass, asdict
+from typing import Iterable, List
+import json
+
+
+@dataclass
+class VariantOutput:
+    """Model output for a single perturbed prompt."""
+
+    prompt_variant: str
+    label: str
+    confidence: float
+
+
+@dataclass
+class PerturbationReport:
+    """Aggregated report summarizing perturbation test results."""
+
+    context_id: str
+    original_label: str
+    perturbation_variants: int
+    match_count: int
+    invariance_score: float
+    avg_confidence_drop: float
+    variant_outputs: List[VariantOutput]
+    is_consistent: bool
+
+
+class ReportFormatter:
+    """Utility to serialize :class:`PerturbationReport` instances."""
+
+    def to_json(self, report: PerturbationReport) -> str:
+        """Serialize ``report`` to a JSON string."""
+        return json.dumps(asdict(report), ensure_ascii=False)
+
+    def to_jsonl(self, reports: Iterable[PerturbationReport]) -> str:
+        """Serialize an iterable of reports into JSON Lines format."""
+        return "\n".join(self.to_json(r) for r in reports)

--- a/utils/llm_inference/score_computer.py
+++ b/utils/llm_inference/score_computer.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+"""Compute robustness scores for perturbation tests."""
+
+from dataclasses import dataclass
+from typing import List
+
+from .llama3_inference import LLMResult
+
+
+@dataclass
+class ScoreResult:
+    """Calculated metrics for a perturbation run."""
+
+    invariance_score: float
+    avg_confidence_drop: float
+
+
+class ScoreComputer:
+    """Calculate invariance and confidence-drop metrics."""
+
+    def compute(
+        self,
+        original_confidence: float,
+        original_label: str,
+        results: List[LLMResult],
+    ) -> ScoreResult:
+        if not results:
+            return ScoreResult(0.0, 0.0)
+        match_count = sum(
+            1 for r in results if r.predicted_label == original_label
+        )
+        invariance = match_count / len(results)
+        avg_drop = (
+            sum(original_confidence - r.confidence for r in results)
+            / len(results)
+        )
+        return ScoreResult(
+            invariance_score=invariance,
+            avg_confidence_drop=avg_drop,
+        )


### PR DESCRIPTION
## Summary
- add perturbation testing framework to evaluate LLaMA3 classification stability
- support generating prompt variants and computing invariance/confidence metrics
- expose tester utilities via `utils.llm_inference`

## Testing
- `flake8 utils/llm_inference/perturbation_tester.py utils/llm_inference/perturbation_generator.py utils/llm_inference/multiprompt_runner.py utils/llm_inference/label_comparer.py utils/llm_inference/score_computer.py utils/llm_inference/report_schema.py utils/llm_inference/__init__.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688c7e6bf988832fa69569cc6d102222