### PR TITLE
feat: add L3 classifier with perturbation testing

### DIFF
--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -1,0 +1,83 @@
+from dataclasses import dataclass
+from typing import Any, Dict, List
+import os
+import sys
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+)
+
+from utils.classifier import LLMClassifier  # noqa: E402
+
+
+@dataclass
+class DummyResult:
+    context_id: str
+    predicted_label: str
+    confidence: float
+    raw_output: str
+    prompt: str
+    logits: Dict[str, float]
+    meta: Dict[str, Any]
+
+
+class DummyInference:
+    def infer(
+        self, context_id: str, context: str, strategy: str = "zero-shot"
+    ) -> DummyResult:
+        return DummyResult(
+            context_id=context_id,
+            predicted_label="primary",
+            confidence=0.9,
+            raw_output="This is a primary citation.",
+            prompt="prompt",
+            logits={"primary": 1.0, "secondary": -1.0, "none": -2.0},
+            meta={
+                "used_strategy": "text2label",
+                "label_source": "direct_label",
+            },
+        )
+
+
+@dataclass
+class DummyReport:
+    context_id: str
+    original_label: str
+    perturbation_variants: int
+    match_count: int
+    invariance_score: float
+    avg_confidence_drop: float
+    variant_outputs: List[Any]
+    is_consistent: bool
+
+
+class DummyTester:
+    def test(
+        self,
+        context_id: str,
+        prompt: str,
+        original_label: str,
+        original_confidence: float,
+    ) -> DummyReport:
+        return DummyReport(
+            context_id=context_id,
+            original_label=original_label,
+            perturbation_variants=1,
+            match_count=1,
+            invariance_score=0.96,
+            avg_confidence_drop=0.0,
+            variant_outputs=[],
+            is_consistent=True,
+        )
+
+
+def test_classifier_with_perturbation():
+    classifier = LLMClassifier(
+        inference=DummyInference(), tester=DummyTester()
+    )
+    prediction = classifier.classify(
+        "some text", context_id="ctx1"
+    )
+    assert prediction.final_label == "primary"
+    assert prediction.is_consistent is True
+    assert prediction.perturbation_score == 0.96

--- a/utils/classifier.py
+++ b/utils/classifier.py
@@ -1,31 +1,97 @@
-"""L3: Classify citations using LLaMA 3."""
+"""L3: High level classifier orchestrating inference and perturbation tests."""
 from __future__ import annotations
 
 from typing import Optional
 
-from .llm_inference import LLaMA3Inference, LLMResult
+from .llm_inference import (
+    LLaMA3Inference,
+    LLMResult,
+    FinalPrediction,
+    PromptPerturbationTester,
+    PerturbationReport,
+)
 
 _MODEL_PATH = "models/llama-3-8b-instruct"
-_inference: Optional[LLaMA3Inference] = None
 
 
-def _get_inference() -> Optional[LLaMA3Inference]:
-    global _inference
-    if _inference is None:
+class LLMClassifier:
+    """Controller that runs inference and optional robustness checks."""
+
+    def __init__(
+        self,
+        inference: Optional[LLaMA3Inference] = None,
+        tester: Optional[PromptPerturbationTester] = None,
+    ) -> None:
+        self.inference = inference or LLaMA3Inference(model_path=_MODEL_PATH)
+        self.tester = tester
+
+    def classify(
+        self,
+        text: str,
+        context_id: str = "ctx_0",
+        strategy: str = "zero-shot",
+        run_perturbation: bool | None = None,
+    ) -> FinalPrediction:
+        """Classify ``text`` and return a :class:`FinalPrediction`.
+
+        When ``run_perturbation`` is ``True`` (default when a tester is
+        provided), the classifier performs prompt perturbation testing and
+        annotates the prediction with consistency metrics.
+        """
+
+        result: LLMResult = self.inference.infer(
+            context_id=context_id, context=text, strategy=strategy
+        )
+        prediction = FinalPrediction(
+            context_id=context_id,
+            final_label=result.predicted_label,
+            confidence=result.confidence,
+            raw_output=result.raw_output,
+            used_strategy=result.meta.get("used_strategy", ""),
+            label_source=result.meta.get("label_source", ""),
+            logits=result.logits,
+        )
+
+        should_run = (
+            run_perturbation
+            if run_perturbation is not None
+            else self.tester is not None
+        )
+        if should_run and self.tester is not None:
+            report: PerturbationReport = self.tester.test(
+                context_id=context_id,
+                prompt=result.prompt,
+                original_label=result.predicted_label,
+                original_confidence=result.confidence,
+            )
+            prediction.is_consistent = report.is_consistent
+            prediction.perturbation_score = report.invariance_score
+        return prediction
+
+
+_classifier: Optional[LLMClassifier] = None
+
+
+def _get_classifier() -> Optional[LLMClassifier]:
+    """Return a cached :class:`LLMClassifier` instance."""
+    global _classifier
+    if _classifier is None:
         try:
-            _inference = LLaMA3Inference(model_path=_MODEL_PATH)
+            inference = LLaMA3Inference(model_path=_MODEL_PATH)
+            tester: Optional[PromptPerturbationTester] = None
+            _classifier = LLMClassifier(inference=inference, tester=tester)
         except Exception:
-            _inference = None
-    return _inference
+            _classifier = None
+    return _classifier
 
 
 def classify_citation(text: str, context_id: str = "ctx_0") -> str:
     """Classify ``text`` and return the predicted label.
 
-    If the model is unavailable, a dummy label is returned instead.
+    If model loading fails, a dummy label is returned.
     """
-    inference = _get_inference()
-    if inference is None:
+    classifier = _get_classifier()
+    if classifier is None:
         return "primary"
-    result: LLMResult = inference.infer(context_id=context_id, context=text)
-    return result.predicted_label
+    prediction = classifier.classify(text=text, context_id=context_id)
+    return prediction.final_label

--- a/utils/llm_inference/output_decoder.py
+++ b/utils/llm_inference/output_decoder.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, Sequence
+from typing import Dict, Sequence, Optional
 
 from .confidence_scorer import ConfidenceScorer
 from .decoding_strategy import DecodingStrategy
@@ -22,12 +22,18 @@ class FinalPrediction:
     used_strategy: str
     label_source: str
     logits: Dict[str, float]
+    is_consistent: Optional[bool] = None
+    perturbation_score: Optional[float] = None
 
 
 class LLMOutputDecoder:
     """High-level decoder combining text and logit cues."""
 
-    def __init__(self, labels: Sequence[str] | None = None, min_confidence: float = 0.0) -> None:
+    def __init__(
+        self,
+        labels: Sequence[str] | None = None,
+        min_confidence: float = 0.0,
+    ) -> None:
         self.labels = list(labels or ["primary", "secondary", "none"])
         self.extractor = LabelExtractor(self.labels)
         self.logit_decoder = LogitDecoder(self.labels)
@@ -42,7 +48,7 @@ class LLMOutputDecoder:
         scores: Sequence[Sequence[float]],
         strategy: DecodingStrategy = DecodingStrategy.TEXT2LABEL,
     ) -> FinalPrediction:
-        """Decode model ``text`` and ``scores`` into a :class:`FinalPrediction`."""
+        """Decode model ``text`` and ``scores`` into a ``FinalPrediction``."""
 
         probs, logits = self.logit_decoder.decode(scores)
         logit_label = max(probs, key=probs.get)


### PR DESCRIPTION
## Summary
- implement `LLMClassifier` orchestrating inference and optional perturbation checks
- extend `FinalPrediction` with consistency metrics and support in decoder
- add unit tests for classifier and perturbation integration

## Testing
- `flake8 utils/classifier.py tests/test_classifier.py utils/llm_inference/output_decoder.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688c814f9474832f9dfc39422f1271a7