### PR TITLE
Add self-questioning module for refinement engine

### DIFF
--- a/data/errors/low_confidence_samples.jsonl
+++ b/data/errors/low_confidence_samples.jsonl
@@ -1,0 +1,1 @@
+{"context_id": "ctx_sample", "text": "Example context", "doc_id": "DOC1", "section": "results", "prediction": "secondary", "confidence": 0.41}

--- a/data/errors/self_questions.jsonl
+++ b/data/errors/self_questions.jsonl
@@ -1,0 +1,1 @@
+{"context_id": "ctx_sample", "question_id": "qst_0001", "question_text": "Is the reference to data truly a primary citation?", "question_type": "classification_challenge", "confidence_level": 0.41, "source": {"doc_id": "DOC1", "section": "results", "original_prediction": "secondary"}}

--- a/notebooks/04_refinement_self_question_test.ipynb
+++ b/notebooks/04_refinement_self_question_test.ipynb
@@ -1,0 +1,35 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from utils.refinement import SelfQuestioner\n",
+    "sq = SelfQuestioner()\n",
+    "context = {\n",
+    "    'context_id': 'ctx1',\n",
+    "    'text': 'This sentence refers to the XYZ dataset for comparison.',\n",
+    "    'doc_id': 'DOC1',\n",
+    "    'section': 'results',\n",
+    "    'confidence': 0.52,\n",
+    "}\n",
+    "questions = sq.generate(context, 'secondary')\n",
+    "questions[:2]"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/test_self_questioner.py
+++ b/tests/test_self_questioner.py
@@ -1,0 +1,19 @@
+from utils.refinement import SelfQuestioner
+from utils.refinement.schema import SelfQuestionItem
+
+
+def test_generate_questions() -> None:
+    questioner = SelfQuestioner()
+    context = {
+        "context_id": "ctx1",
+        "text": "This sentence refers to the XYZ dataset for comparison.",
+        "doc_id": "DOC1",
+        "section": "results",
+        "confidence": 0.52,
+    }
+    prediction = "secondary"
+
+    questions = questioner.generate(context, prediction)
+
+    assert questions, "No questions generated"
+    assert isinstance(questions[0], SelfQuestionItem)

--- a/utils/refinement/__init__.py
+++ b/utils/refinement/__init__.py
@@ -1,6 +1,11 @@
 """L4: Self-refinement loop utilities."""
 
+from .self_questioner import SelfQuestioner
+
 
 def refine_prediction(prediction: str) -> str:
     """Placeholder refinement that echoes the prediction."""
     return prediction
+
+
+__all__ = ["SelfQuestioner", "refine_prediction"]

--- a/utils/refinement/schema.py
+++ b/utils/refinement/schema.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass
+class SelfQuestionItem:
+    """Structured representation of a self-generated question."""
+
+    context_id: str
+    question_id: str
+    question_text: str
+    question_type: str
+    confidence_level: float
+    source: Dict[str, str]

--- a/utils/refinement/self_questioner.py
+++ b/utils/refinement/self_questioner.py
@@ -1,0 +1,59 @@
+import uuid
+from typing import Dict, List
+
+from .semantic_focus import SemanticFocusAnalyzer
+from .template_bank import QuestionTemplateBank
+from .template_renderer import TemplateRenderer
+from .schema import SelfQuestionItem
+
+
+class SelfQuestioner:
+    """Generate self-questions to trigger the refinement loop."""
+
+    def __init__(
+        self,
+        template_bank: QuestionTemplateBank | None = None,
+        focus_analyzer: SemanticFocusAnalyzer | None = None,
+        renderer: TemplateRenderer | None = None,
+    ) -> None:
+        self.template_bank = template_bank or QuestionTemplateBank()
+        self.focus_analyzer = focus_analyzer or SemanticFocusAnalyzer()
+        self.renderer = renderer or TemplateRenderer()
+
+    def generate(
+        self, context_unit: Dict, prediction: str
+    ) -> List[SelfQuestionItem]:
+        """Create self-questions given a context and model prediction."""
+
+        text = context_unit.get("text", "")
+        context_id = context_unit.get("context_id", "")
+        doc_id = context_unit.get("doc_id")
+        section = context_unit.get("section")
+        confidence = float(context_unit.get("confidence", 0.0))
+
+        focus_terms = self.focus_analyzer.extract_focus_terms(text)
+        questions: List[SelfQuestionItem] = []
+
+        for qtype in self.template_bank.templates.keys():
+            templates = self.template_bank.get_templates(qtype)
+            for focus in focus_terms:
+                for tmpl in templates:
+                    question_text = self.renderer.render(
+                        tmpl, focus=focus, prediction=prediction
+                    )
+                    question_id = f"qst_{uuid.uuid4().hex[:8]}"
+                    questions.append(
+                        SelfQuestionItem(
+                            context_id=context_id,
+                            question_id=question_id,
+                            question_text=question_text,
+                            question_type=qtype,
+                            confidence_level=confidence,
+                            source={
+                                "doc_id": doc_id or "",
+                                "section": section or "",
+                                "original_prediction": prediction,
+                            },
+                        )
+                    )
+        return questions

--- a/utils/refinement/semantic_focus.py
+++ b/utils/refinement/semantic_focus.py
@@ -1,0 +1,20 @@
+import re
+from collections import Counter
+from typing import Iterable, List
+
+
+class SemanticFocusAnalyzer:
+    """Naive keyword extractor used to guide question generation."""
+
+    def __init__(self, stop_words: Iterable[str] | None = None) -> None:
+        self.stop_words = set(
+            stop_words or {"the", "and", "for", "with", "that", "this", "from"}
+        )
+
+    def extract_focus_terms(self, text: str, top_k: int = 2) -> List[str]:
+        """Return up to ``top_k`` keywords from ``text``."""
+
+        tokens = re.findall(r"\w+", text.lower())
+        tokens = [t for t in tokens if t not in self.stop_words and len(t) > 3]
+        counts = Counter(tokens)
+        return [t for t, _ in counts.most_common(top_k)]

--- a/utils/refinement/template_bank.py
+++ b/utils/refinement/template_bank.py
@@ -1,0 +1,32 @@
+from typing import Dict, List
+
+
+class QuestionTemplateBank:
+    """Repository for self-question templates grouped by type."""
+
+    def __init__(self) -> None:
+        self.templates: Dict[str, List[str]] = {
+            "classification_challenge": [
+                (
+                    "Is the reference to ${focus} truly a ${prediction} "
+                    "citation, or does it play another role?"
+                ),
+            ],
+            "semantic_contrast": [
+                (
+                    "How would the interpretation change if ${focus} were "
+                    "considered primary evidence?"
+                ),
+            ],
+            "detail_check": [
+                "What specific data about ${focus} is being referenced here?",
+            ],
+            "self_reflection": [
+                "Can you justify labeling ${focus} as ${prediction}?",
+            ],
+        }
+
+    def get_templates(self, question_type: str) -> List[str]:
+        """Return templates for a given question type."""
+
+        return self.templates.get(question_type, [])

--- a/utils/refinement/template_renderer.py
+++ b/utils/refinement/template_renderer.py
@@ -1,0 +1,8 @@
+from string import Template
+
+
+class TemplateRenderer:
+    """Render question templates using string.Template."""
+
+    def render(self, template_str: str, **kwargs: str) -> str:
+        return Template(template_str).safe_substitute(**kwargs)


### PR DESCRIPTION
## Summary
- introduce SelfQuestioner to generate context-aware follow-up questions
- provide template bank, focus analyzer, renderer, and schema helpers
- log self-question samples and add notebook & tests

## Testing
- `flake8 utils/refinement tests/test_self_questioner.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688c8b01fdd0832f88bd6d1a300931e1