### PR TITLE
Add refinement engine orchestrator and metadata logging

### DIFF
--- a/tests/test_refinement_engine.py
+++ b/tests/test_refinement_engine.py
@@ -1,0 +1,52 @@
+from dataclasses import dataclass
+
+from utils.refinement import RefinementEngine, SelfCorrector, SelfQuestioner
+from utils.refinement.correction_engine import CorrectionEngine
+from utils.refinement.schema import CorrectionProposal
+
+
+@dataclass
+class DummyResult:
+    context_id: str
+    predicted_label: str
+    confidence: float
+    raw_output: str
+    prompt: str
+    logits: dict
+    meta: dict
+
+
+class DummyInference:
+    def infer(self, context_id: str, context: str) -> DummyResult:  # type: ignore[override]
+        return DummyResult(
+            context_id=context_id,
+            predicted_label="primary",
+            confidence=0.9,
+            raw_output="",
+            prompt=context,
+            logits={},
+            meta={},
+        )
+
+
+def test_refinement_engine_flow() -> None:
+    corrector = SelfCorrector(engine=CorrectionEngine(inference=DummyInference()))
+    engine = RefinementEngine(questioner=SelfQuestioner(), corrector=corrector)
+
+    context = {"context_id": "ctx1", "text": "This refers to the XYZ dataset."}
+    original = DummyResult(
+        context_id="ctx1",
+        predicted_label="secondary",
+        confidence=0.6,
+        raw_output="",
+        prompt="",
+        logits={},
+        meta={},
+    )
+
+    proposals = engine.run(context, original)
+
+    assert proposals, "No proposals produced"
+    assert isinstance(proposals[0], CorrectionProposal)
+    assert proposals[0].accepted is True
+    assert proposals[0].corrected_label == "primary"

--- a/utils/refinement/__init__.py
+++ b/utils/refinement/__init__.py
@@ -1,12 +1,8 @@
 """L4: Self-refinement loop utilities."""
 
+from .refinement_engine import RefinementEngine
 from .self_questioner import SelfQuestioner
 from .self_corrector import SelfCorrector
 
 
-def refine_prediction(prediction: str) -> str:
-    """Placeholder refinement that echoes the prediction."""
-    return prediction
-
-
-__all__ = ["SelfQuestioner", "SelfCorrector", "refine_prediction"]
+__all__ = ["SelfQuestioner", "SelfCorrector", "RefinementEngine"]

--- a/utils/refinement/refinement_engine.py
+++ b/utils/refinement/refinement_engine.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+from utils.llm_inference import LLMResult
+
+from .self_questioner import SelfQuestioner
+from .self_corrector import SelfCorrector
+from .schema import CorrectionProposal
+
+
+class RefinementEngine:
+    """Coordinate self-questioning and correction steps."""
+
+    def __init__(
+        self,
+        questioner: SelfQuestioner | None = None,
+        corrector: SelfCorrector | None = None,
+    ) -> None:
+        self.questioner = questioner or SelfQuestioner()
+        self.corrector = corrector or SelfCorrector()
+
+    def run(
+        self, context_unit: Dict, original_pred: LLMResult
+    ) -> List[CorrectionProposal]:
+        """Generate questions and attempt corrections."""
+
+        proposals: List[CorrectionProposal] = []
+        questions = self.questioner.generate(
+            context_unit, original_pred.predicted_label
+        )
+        for question in questions:
+            proposals.append(
+                self.corrector.correct(context_unit, question, original_pred)
+            )
+        return proposals

--- a/utils/refinement/schema.py
+++ b/utils/refinement/schema.py
@@ -27,6 +27,7 @@ class CorrectionProposal:
     correction_reason: str
     accepted: bool
     question_id: str
+    metadata: Dict[str, str | float] | None = None
 
 
 @dataclass

--- a/utils/refinement/self_corrector.py
+++ b/utils/refinement/self_corrector.py
@@ -47,6 +47,12 @@ class SelfCorrector:
             corrected_label=result.predicted_label,
             corrected_confidence=result.confidence,
         )
+        metadata = {
+            "original_confidence": original_pred.confidence,
+            "corrected_confidence": result.confidence,
+            "reask_prompt": prompt,
+            "raw_response": getattr(result, "raw_output", ""),
+        }
         proposal = CorrectionProposal(
             context_id=self_question.context_id,
             original_label=original_pred.predicted_label,
@@ -57,6 +63,7 @@ class SelfCorrector:
             correction_reason=reason,
             accepted=accepted,
             question_id=self_question.question_id,
+            metadata=metadata,
         )
         if self.logger:
             self.logger.log(proposal)


### PR DESCRIPTION
## Summary
- Add `RefinementEngine` to coordinate question generation and correction passes
- Expand `CorrectionProposal` with metadata and capture prompt/response details in `SelfCorrector`
- Test integration of self-questioner and self-corrector via the new engine

## Testing
- `ruff check utils/refinement tests/test_self_corrector.py tests/test_self_questioner.py tests/test_refinement_engine.py`
- `PYTHONPATH=. pytest tests/test_self_questioner.py tests/test_self_corrector.py tests/test_refinement_engine.py -q`
- `PYTHONPATH=. pytest -q` *(fails: No module named 'transformers')*


------
https://chatgpt.com/codex/tasks/task_e_688c94058a44832f91fe6bdf88cdd034