### PR TITLE
Add PromptPairGenerator for CIT data creation

### DIFF
--- a/tests/test_prompt_pair_generator.py
+++ b/tests/test_prompt_pair_generator.py
@@ -1,0 +1,57 @@
+from utils.meta_cognition import ErrorRecord, ErrorType, PromptPairGenerator
+from utils.meta_cognition.schema import ContrastivePromptPair, PromptPairItem
+from utils.meta_cognition.strategy_engine import PairStrategyEngine
+from utils.refinement.schema import CorrectionProposal
+
+
+def _make_error_and_correction():
+    error = ErrorRecord(
+        error_id="e1",
+        context_id="c1",
+        error_type=ErrorType.CLASSIFICATION_ERROR,
+        source_module="unit",
+        predicted_label="secondary",
+        meta={"prompt": "context text", "question": "Is this new data?"},
+    )
+    correction = CorrectionProposal(
+        context_id="c1",
+        original_label="secondary",
+        corrected_label="primary",
+        original_confidence=0.5,
+        corrected_confidence=0.9,
+        confidence_delta=0.4,
+        correction_reason="It references newly generated data.",
+        accepted=True,
+        question_id="q1",
+    )
+    return error, correction
+
+
+def test_generate_direct() -> None:
+    error, correction = _make_error_and_correction()
+    gen = PromptPairGenerator()
+    pairs = gen.generate([error], [correction])
+    assert isinstance(pairs[0], PromptPairItem)
+    assert pairs[0].output == "primary"
+
+
+def test_generate_contrastive() -> None:
+    error, correction = _make_error_and_correction()
+    engine = PairStrategyEngine(mode="contrastive")
+    gen = PromptPairGenerator(strategy_engine=engine)
+    pairs = gen.generate([error], [correction])
+    pair = pairs[0]
+    assert isinstance(pair, ContrastivePromptPair)
+    assert pair.positive.output == "primary"
+    assert pair.negative.output == "secondary"
+
+
+def test_generate_qa() -> None:
+    error, correction = _make_error_and_correction()
+    engine = PairStrategyEngine(mode="qa")
+    gen = PromptPairGenerator(strategy_engine=engine)
+    pairs = gen.generate([error], [correction])
+    item = pairs[0]
+    assert isinstance(item, PromptPairItem)
+    assert "Q:" in item.input
+    assert item.output == "primary"

--- a/utils/meta_cognition/__init__.py
+++ b/utils/meta_cognition/__init__.py
@@ -2,12 +2,22 @@
 
 from .error_logger import ErrorLogger
 from .error_query import ErrorQueryAPI
-from .schema import ErrorRecord, ErrorType, ErrorSource
+from .prompt_pair_generator import PromptPairGenerator
+from .schema import (
+    ContrastivePromptPair,
+    ErrorRecord,
+    ErrorSource,
+    ErrorType,
+    PromptPairItem,
+)
 
 __all__ = [
     "ErrorLogger",
     "ErrorQueryAPI",
+    "PromptPairGenerator",
     "ErrorRecord",
     "ErrorType",
     "ErrorSource",
+    "PromptPairItem",
+    "ContrastivePromptPair",
 ]

--- a/utils/meta_cognition/exporter.py
+++ b/utils/meta_cognition/exporter.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, Union
+
+from .schema import ContrastivePromptPair, PromptPairItem
+
+
+class PairExporter:
+    """Export prompt pairs to various file formats."""
+
+    def to_jsonl(
+        self,
+        items: Iterable[Union[PromptPairItem, ContrastivePromptPair]],
+        path: str,
+    ) -> None:
+        path_obj = Path(path)
+        with path_obj.open("w", encoding="utf-8") as f:
+            for item in items:
+                f.write(json.dumps(item.to_dict(), ensure_ascii=False) + "\n")

--- a/utils/meta_cognition/pair_filter.py
+++ b/utils/meta_cognition/pair_filter.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Iterable, List, Tuple
+
+from utils.refinement.schema import CorrectionProposal
+
+from .schema import ErrorRecord
+
+
+class PairFilter:
+    """Select valid error-correction pairs for prompt generation."""
+
+    def __init__(
+        self,
+        min_confidence_delta: float = 0.0,
+        require_label_flip: bool = True,
+    ) -> None:
+        self.min_confidence_delta = min_confidence_delta
+        self.require_label_flip = require_label_flip
+
+    def select(
+        self,
+        errors: Iterable[ErrorRecord],
+        corrections: Iterable[CorrectionProposal],
+    ) -> List[Tuple[ErrorRecord, CorrectionProposal]]:
+        corr_map = {c.context_id: c for c in corrections if c.accepted}
+        selected: List[Tuple[ErrorRecord, CorrectionProposal]] = []
+        for err in errors:
+            corr = corr_map.get(err.context_id)
+            if corr is None:
+                continue
+            if (
+                self.require_label_flip
+                and corr.corrected_label == err.predicted_label
+            ):
+                continue
+            if corr.confidence_delta < self.min_confidence_delta:
+                continue
+            selected.append((err, corr))
+        return selected

--- a/utils/meta_cognition/prompt_assembler.py
+++ b/utils/meta_cognition/prompt_assembler.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+
+class PromptAssembler:
+    """Utility to compose prompt text from components."""
+
+    def assemble_input(
+        self,
+        context: str,
+        question: str | None = None,
+        answer: str | None = None,
+    ) -> str:
+        parts: list[str] = []
+        if question and answer:
+            parts.append(f"Q: {question}\nA: {answer}")
+        if context:
+            parts.append(context)
+        return "\n\n".join(parts).strip()

--- a/utils/meta_cognition/prompt_pair_generator.py
+++ b/utils/meta_cognition/prompt_pair_generator.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Iterable, List, Optional
+
+from utils.refinement.schema import CorrectionProposal
+
+from .pair_filter import PairFilter
+from .schema import ContrastivePromptPair, ErrorRecord, PromptPairItem
+from .strategy_engine import PairStrategyEngine
+
+
+class PromptPairGenerator:
+    """High level interface to build prompt pairs from logged errors."""
+
+    def __init__(
+        self,
+        strategy_engine: Optional[PairStrategyEngine] = None,
+        pair_filter: Optional[PairFilter] = None,
+    ) -> None:
+        self.strategy_engine = strategy_engine or PairStrategyEngine()
+        self.filter = pair_filter or PairFilter()
+
+    def generate(
+        self,
+        errors: Iterable[ErrorRecord],
+        corrections: Iterable[CorrectionProposal],
+    ) -> List[PromptPairItem | ContrastivePromptPair]:
+        selected = self.filter.select(errors, corrections)
+        return [
+            self.strategy_engine.build(err, corr)
+            for err, corr in selected
+        ]

--- a/utils/meta_cognition/schema.py
+++ b/utils/meta_cognition/schema.py
@@ -59,3 +59,29 @@ class ErrorRecord:
         data = data.copy()
         data["error_type"] = ErrorType(data["error_type"])
         return cls(**data)
+
+
+@dataclass
+class PromptPairItem:
+    """Standard instruction tuning sample."""
+
+    instruction: str
+    input: str
+    output: str
+
+    def to_dict(self) -> Dict[str, str]:  # pragma: no cover - simple helper
+        return asdict(self)
+
+
+@dataclass
+class ContrastivePromptPair:
+    """Positive and negative sample for contrastive tuning."""
+
+    positive: PromptPairItem
+    negative: PromptPairItem
+
+    def to_dict(self) -> Dict[str, Any]:  # pragma: no cover - simple helper
+        return {
+            "positive": self.positive.to_dict(),
+            "negative": self.negative.to_dict(),
+        }

--- a/utils/meta_cognition/strategy_engine.py
+++ b/utils/meta_cognition/strategy_engine.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from utils.refinement.schema import CorrectionProposal
+
+from .prompt_assembler import PromptAssembler
+from .schema import ContrastivePromptPair, ErrorRecord, PromptPairItem
+
+
+class PairStrategyEngine:
+    """Generate prompt pairs using different strategies."""
+
+    def __init__(
+        self,
+        mode: str = "direct",
+        assembler: Optional[PromptAssembler] = None,
+    ) -> None:
+        self.mode = mode
+        self.assembler = assembler or PromptAssembler()
+
+    def build(
+        self, error: ErrorRecord, correction: CorrectionProposal
+    ) -> PromptPairItem | ContrastivePromptPair:
+        context = error.meta.get("prompt", "")
+        question = error.meta.get("question")
+        answer = correction.correction_reason
+
+        if self.mode == "direct":
+            instruction = (
+                "Classify the citation type in the following context."
+            )
+            input_text = self.assembler.assemble_input(context)
+            output = correction.corrected_label
+            return PromptPairItem(instruction, input_text, output)
+
+        if self.mode == "qa":
+            instruction = (
+                "Based on the self-question, determine the correct citation "
+                "type."
+            )
+            input_text = self.assembler.assemble_input(
+                context, question, answer
+            )
+            output = correction.corrected_label
+            return PromptPairItem(instruction, input_text, output)
+
+        if self.mode == "contrastive":
+            instruction = (
+                "Classify the citation type in the following context."
+            )
+            base_input = self.assembler.assemble_input(context)
+            positive = PromptPairItem(
+                instruction,
+                base_input,
+                correction.corrected_label,
+            )
+            negative = PromptPairItem(
+                instruction,
+                base_input,
+                error.predicted_label or "",
+            )
+            return ContrastivePromptPair(positive=positive, negative=negative)
+
+        raise ValueError(f"Unknown strategy: {self.mode}")


### PR DESCRIPTION
## Summary
- implement PromptPairGenerator with filtering and strategy-based pair construction
- add supporting modules for assembling inputs, exporting pairs, and strategy selection
- include PromptPairItem and ContrastivePromptPair schemas

## Testing
- `flake8 utils/meta_cognition/prompt_assembler.py utils/meta_cognition/pair_filter.py utils/meta_cognition/strategy_engine.py utils/meta_cognition/exporter.py utils/meta_cognition/prompt_pair_generator.py tests/test_prompt_pair_generator.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688c9bcfba40832fa82f66576bb7094b