### PR TITLE
Add LoRA fine-tuning utilities

### DIFF
--- a/utils/meta_cognition/__init__.py
+++ b/utils/meta_cognition/__init__.py
@@ -3,6 +3,11 @@
 from .error_logger import ErrorLogger
 from .error_query import ErrorQueryAPI
 from .prompt_pair_generator import PromptPairGenerator
+
+try:  # pragma: no cover - optional dependency
+    from .lora_fine_tuner import LoRAFineTuner
+except Exception:  # noqa: BLE001 - fallback when transformers is missing
+    LoRAFineTuner = None
 from .schema import (
     ContrastivePromptPair,
     ErrorRecord,
@@ -20,4 +25,5 @@ __all__ = [
     "ErrorSource",
     "PromptPairItem",
     "ContrastivePromptPair",
+    "LoRAFineTuner",
 ]

--- a/utils/meta_cognition/data_preprocessor.py
+++ b/utils/meta_cognition/data_preprocessor.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from datasets import Dataset
+from transformers import PreTrainedTokenizerBase
+
+from .schema import PromptPairItem
+
+
+@dataclass
+class DataPreprocessor:
+    """Convert :class:`PromptPairItem` into tokenized datasets."""
+
+    tokenizer: PreTrainedTokenizerBase
+    max_length: int = 2048
+
+    def to_dataset(self, pairs: Iterable[PromptPairItem]) -> Dataset:
+        """Build a :class:`datasets.Dataset` for language model tuning."""
+
+        def gen():
+            for item in pairs:
+                prompt = item.instruction
+                if item.input:
+                    prompt += "\n" + item.input
+                yield {"prompt": prompt, "response": item.output}
+
+        dataset = Dataset.from_generator(gen)
+
+        def tokenize(batch):
+            sources = self.tokenizer(
+                batch["prompt"], truncation=True, max_length=self.max_length
+            )
+            targets = self.tokenizer(
+                batch["response"], truncation=True, max_length=self.max_length
+            )
+            return {
+                "input_ids": sources["input_ids"],
+                "labels": targets["input_ids"],
+            }
+
+        return dataset.map(
+            tokenize, batched=True, remove_columns=["prompt", "response"]
+        )

--- a/utils/meta_cognition/eval_monitor.py
+++ b/utils/meta_cognition/eval_monitor.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from transformers import Trainer
+
+
+@dataclass
+class EvalMonitor:
+    """Simple evaluation helper for fine-tuned models."""
+
+    def accuracy(self, preds: Iterable[str], labels: Iterable[str]) -> float:
+        pairs = list(zip(preds, labels))
+        if not pairs:
+            return 0.0
+        correct = sum(p == l for p, l in pairs)
+        return correct / len(pairs)
+
+    def evaluate(self, trainer: Trainer, dataset) -> dict:
+        """Run evaluation using the provided trainer and dataset."""
+        metrics = trainer.evaluate(dataset)
+        predictions = trainer.predict(dataset)
+        decoded_preds = trainer.tokenizer.batch_decode(
+            predictions.predictions, skip_special_tokens=True
+        )
+        decoded_labels = trainer.tokenizer.batch_decode(
+            dataset["labels"], skip_special_tokens=True
+        )
+        metrics["accuracy"] = self.accuracy(decoded_preds, decoded_labels)
+        return metrics

--- a/utils/meta_cognition/lora_fine_tuner.py
+++ b/utils/meta_cognition/lora_fine_tuner.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Type
+
+from transformers import PreTrainedModel, PreTrainedTokenizerBase
+
+from .data_preprocessor import DataPreprocessor
+from .eval_monitor import EvalMonitor
+from .lora_model_manager import LoRAModelManager
+from .schema import PromptPairItem
+from .trainer_builder import TrainerBuilder
+
+
+@dataclass
+class LoRAFineTuner:
+    """High level interface to perform LoRA fine-tuning on prompt pairs."""
+
+    model: PreTrainedModel
+    tokenizer: PreTrainedTokenizerBase
+    model_manager: LoRAModelManager
+    trainer_builder_cls: Type[TrainerBuilder] = TrainerBuilder
+    data_preprocessor_cls: Type[DataPreprocessor] = DataPreprocessor
+    eval_monitor: EvalMonitor = EvalMonitor()
+
+    def train(self, pairs: Iterable[PromptPairItem], **kwargs):
+        preprocessor = self.data_preprocessor_cls(self.tokenizer)
+        dataset = preprocessor.to_dataset(pairs)
+        builder = self.trainer_builder_cls(self.model, self.tokenizer)
+        trainer = builder.build(train_dataset=dataset, **kwargs)
+        trainer.train()
+        version = kwargs.get("version", "latest")
+        self.model_manager.save(trainer.model, version)
+        return trainer
+
+    def evaluate(self, trainer, pairs: Iterable[PromptPairItem]):
+        preprocessor = self.data_preprocessor_cls(self.tokenizer)
+        dataset = preprocessor.to_dataset(pairs)
+        return self.eval_monitor.evaluate(trainer, dataset)

--- a/utils/meta_cognition/lora_model_manager.py
+++ b/utils/meta_cognition/lora_model_manager.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from peft import PeftModel
+
+
+@dataclass
+class LoRAModelManager:
+    """Utility to save and load LoRA adapter weights."""
+
+    save_dir: Path
+
+    def save(
+        self,
+        model: PeftModel,
+        version: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Path:
+        path = self.save_dir / version
+        path.mkdir(parents=True, exist_ok=True)
+        model.save_pretrained(path)
+        if metadata is not None:
+            with open(path / "meta.json", "w", encoding="utf-8") as fh:
+                json.dump(metadata, fh, indent=2)
+        return path
+
+    def load(self, base_model, version: str) -> PeftModel:
+        path = self.save_dir / version
+        return PeftModel.from_pretrained(base_model, path)

--- a/utils/meta_cognition/trainer_builder.py
+++ b/utils/meta_cognition/trainer_builder.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from peft import LoraConfig, get_peft_model
+from transformers import (
+    PreTrainedModel,
+    PreTrainedTokenizerBase,
+    Trainer,
+    TrainingArguments,
+)
+
+
+@dataclass
+class TrainerBuilder:
+    """Build a Trainer configured for LoRA fine-tuning."""
+
+    base_model: PreTrainedModel
+    tokenizer: PreTrainedTokenizerBase
+    peft_config: Optional[LoraConfig] = None
+
+    def build(self, train_dataset, eval_dataset=None, **kwargs) -> Trainer:
+        config = self.peft_config or LoraConfig(
+            r=8,
+            lora_alpha=16,
+            target_modules=["q_proj", "v_proj"],
+            lora_dropout=0.05,
+            bias="none",
+            task_type="CAUSAL_LM",
+        )
+        model = get_peft_model(self.base_model, config)
+        args = kwargs.get("args") or TrainingArguments(
+            output_dir="lora_outputs",
+            per_device_train_batch_size=1,
+            num_train_epochs=1,
+            learning_rate=5e-5,
+            logging_steps=10,
+        )
+        return Trainer(
+            model=model,
+            args=args,
+            train_dataset=train_dataset,
+            eval_dataset=eval_dataset,
+            tokenizer=self.tokenizer,
+        )


### PR DESCRIPTION
## Summary
- add DataPreprocessor to turn prompt pairs into tokenized datasets
- provide TrainerBuilder and LoRAModelManager to configure and save LoRA adapters
- implement LoRAFineTuner and EvalMonitor for training and evaluation, exporting trainer optionally

## Testing
- `flake8 utils/meta_cognition/__init__.py utils/meta_cognition/data_preprocessor.py utils/meta_cognition/trainer_builder.py utils/meta_cognition/eval_monitor.py utils/meta_cognition/lora_model_manager.py utils/meta_cognition/lora_fine_tuner.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688c9e433fec832f9960848369163feb