### PR TITLE
feat: add meta learning loop

### DIFF
--- a/tests/test_meta_loop.py
+++ b/tests/test_meta_loop.py
@@ -1,0 +1,42 @@
+from utils.meta_loop import run_meta_loop
+from utils.meta_cognition import ErrorRecord, ErrorType
+from utils.refinement.schema import CorrectionProposal
+
+
+def make_error_and_correction():
+    error = ErrorRecord(
+        error_id="e1",
+        context_id="c1",
+        error_type=ErrorType.CLASSIFICATION_ERROR,
+        source_module="unit",
+        predicted_label="secondary",
+        meta={"prompt": "context", "question": "Is this new data?"},
+    )
+    correction = CorrectionProposal(
+        context_id="c1",
+        original_label="secondary",
+        corrected_label="primary",
+        original_confidence=0.5,
+        corrected_confidence=0.9,
+        confidence_delta=0.4,
+        correction_reason="It references new data.",
+        accepted=True,
+        question_id="q1",
+    )
+    return error, correction
+
+
+def test_run_meta_loop_logs_and_generates(tmp_path):
+    error, correction = make_error_and_correction()
+    pairs, metrics = run_meta_loop(
+        [error],
+        [correction],
+        model=None,
+        tokenizer=None,
+        error_dir=tmp_path / "errors",
+        adapter_dir=tmp_path / "adapters",
+    )
+    assert pairs[0].output == "primary"
+    assert metrics == {}
+    log_file = tmp_path / "errors" / "all_errors.jsonl"
+    assert log_file.exists()

--- a/utils/meta_loop.py
+++ b/utils/meta_loop.py
@@ -1,6 +1,81 @@
-"""L5: Meta-training loop for continual learning."""
+"""L5: Meta-training loop for continual learning.
+
+This module wires together the components that make up the
+meta-cognition layer.  It provides a small ``run_meta_loop`` helper that
+logs error samples, turns them into prompt pairs and (optionally) performs
+LoRA fine-tuning on those pairs.
+
+The function is intentionally lightweight – it does not aim to be a full
+pipeline manager but rather a reference implementation that can be
+expanded upon.  When a ``model`` and ``tokenizer`` are not supplied the
+fine‑tuning step is skipped which makes the function convenient to use in
+tests or smaller workflows.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Tuple
+
+from utils.meta_cognition import (
+    ErrorLogger,
+    ErrorRecord,
+    LoRAFineTuner,
+    PromptPairGenerator,
+)
+from utils.meta_cognition.error_storage import ErrorStorageManager
+from utils.refinement.schema import CorrectionProposal
 
 
-def run_meta_loop() -> None:
-    """Placeholder meta loop."""
-    pass
+def run_meta_loop(
+    errors: Iterable[ErrorRecord],
+    corrections: Iterable[CorrectionProposal],
+    model=None,
+    tokenizer=None,
+    *,
+    error_dir: str | Path = "data/errors",
+    adapter_dir: str | Path = "models/lora_adapters",
+    **tuner_kwargs,
+) -> Tuple[list, dict]:
+    """Execute the meta-learning cycle.
+
+    Parameters
+    ----------
+    errors, corrections:
+        Iterables of :class:`ErrorRecord` and
+        :class:`~utils.refinement.schema.CorrectionProposal` respectively.
+    model, tokenizer:
+        When provided the function will fine‑tune ``model`` using the
+        generated prompt pairs.  If either is ``None`` the fine‑tuning step
+        is skipped.
+    error_dir, adapter_dir:
+        Directories used for error persistence and saving LoRA adapters.
+    tuner_kwargs:
+        Additional keyword arguments forwarded to
+        :meth:`LoRAFineTuner.train`.
+
+    Returns
+    -------
+    Tuple[List[PromptPairItem | ContrastivePromptPair], Dict[str, float]]
+        A tuple containing the generated prompt pairs and evaluation
+        metrics (empty when fine‑tuning is skipped).
+    """
+
+    logger = ErrorLogger(storage=ErrorStorageManager(error_dir))
+    for record in errors:
+        logger.log(record)
+
+    generator = PromptPairGenerator()
+    pairs = generator.generate(errors, corrections)
+
+    metrics = {}
+    if model is not None and tokenizer is not None and LoRAFineTuner is not None:
+        from utils.meta_cognition.lora_model_manager import LoRAModelManager
+
+        manager = LoRAModelManager(Path(adapter_dir))
+        tuner = LoRAFineTuner(model, tokenizer, manager)
+        trainer = tuner.train(pairs, **tuner_kwargs)
+        metrics = tuner.evaluate(trainer, pairs)
+
+    return pairs, metrics
+


### PR DESCRIPTION
## Summary
- add runnable meta-learning loop that logs errors, builds prompt pairs, and optionally fine-tunes LoRA adapters
- cover meta loop with tests

## Testing
- `ruff check utils/meta_loop.py tests/test_meta_loop.py`
- `PYTHONPATH=. pytest tests/test_error_logger.py tests/test_prompt_pair_generator.py tests/test_meta_loop.py -q`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_688ca142b624832fadf410fcc5e3fe4b