### PR TITLE
feat: add semantic context retriever

### DIFF
--- a/tests/test_context_retriever.py
+++ b/tests/test_context_retriever.py
@@ -1,0 +1,88 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import numpy as np
+
+from utils.retriever import (
+    ContextRetriever,
+    EmbeddingEncoder,
+    IndexStorageManager,
+    VectorIndexer,
+)
+
+
+class DummyModel:
+    def encode(self, texts):
+        vectors = []
+        for t in texts:
+            v = np.zeros(3, dtype="float32")
+            if "cat" in t:
+                v[0] = 1.0
+            if "dog" in t:
+                v[1] = 1.0
+            if "bird" in t:
+                v[2] = 1.0
+            vectors.append(v)
+        return np.vstack(vectors)
+
+
+def build_retriever():
+    model = DummyModel()
+    encoder = EmbeddingEncoder(model=model)
+    indexer = VectorIndexer(dimension=3, metric="cosine")
+    metadata = [
+        {
+            "text": "The cat sat on the mat.",
+            "doc_id": "d1",
+            "context_id": "c1",
+            "section": "methods",
+        },
+        {
+            "text": "Dogs are friendly animals.",
+            "doc_id": "d2",
+            "context_id": "c2",
+            "section": "results",
+        },
+        {
+            "text": "Birds can fly high.",
+            "doc_id": "d3",
+            "context_id": "c3",
+            "section": "discussion",
+        },
+    ]
+    vectors = encoder.encode([m["text"] for m in metadata])
+    indexer.add(vectors)
+    return ContextRetriever(
+        encoder=encoder, indexer=indexer, metadata=metadata
+    )
+
+
+def test_retrieve_basic():
+    retriever = build_retriever()
+    results = retriever.retrieve("cat", top_k=1)
+    assert results
+    assert results[0].doc_id == "d1"
+
+
+def test_retrieve_with_filters():
+    retriever = build_retriever()
+    results = retriever.retrieve(
+        "dog", top_k=2, filters={"section": "results"}
+    )
+    assert results
+    assert results[0].doc_id == "d2"
+    assert all(r.section == "results" for r in results)
+
+
+def test_index_storage_roundtrip(tmp_path):
+    retriever = build_retriever()
+    storage = IndexStorageManager(
+        index_path=tmp_path / "faiss.index",
+        metadata_path=tmp_path / "meta.json",
+    )
+    storage.save(retriever.indexer, retriever.metadata)
+    new_retriever = ContextRetriever.from_storage(retriever.encoder, storage)
+    results = new_retriever.retrieve("bird", top_k=1)
+    assert results[0].doc_id == "d3"

--- a/utils/retriever.py
+++ b/utils/retriever.py
@@ -1,6 +1,15 @@
 """L6: Retrieval utilities for memory stores."""
 
+from .retriever.context_retriever import ContextRetriever
+
+__all__ = ["ContextRetriever", "retrieve"]
+
 
 def retrieve(query: str) -> list[str]:
-    """Placeholder retriever returning an empty list."""
+    """Placeholder retriever returning an empty list.
+
+    The :class:`ContextRetriever` class in ``utils.retriever`` provides the
+    full semantic retrieval implementation.
+    """
+
     return []

--- a/utils/retriever/__init__.py
+++ b/utils/retriever/__init__.py
@@ -1,0 +1,17 @@
+"""Utilities for semantic context retrieval."""
+
+from .context_retriever import ContextRetriever
+from .embedding_encoder import EmbeddingEncoder
+from .vector_indexer import VectorIndexer
+from .index_storage import IndexStorageManager
+from .context_filter import ContextFilter
+from .schema import RetrievalResultItem
+
+__all__ = [
+    "ContextRetriever",
+    "EmbeddingEncoder",
+    "VectorIndexer",
+    "IndexStorageManager",
+    "ContextFilter",
+    "RetrievalResultItem",
+]

--- a/utils/retriever/context_filter.py
+++ b/utils/retriever/context_filter.py
@@ -1,0 +1,20 @@
+"""Metadata based filtering utilities."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List
+
+
+class ContextFilter:
+    """Filter context metadata according to field equality."""
+
+    @staticmethod
+    def match(metadata: dict, filters: Dict[str, str]) -> bool:
+        return all(metadata.get(k) == v for k, v in filters.items())
+
+    def apply(
+        self, ids: Iterable[int], metadata: List[dict], filters: Dict[str, str]
+    ) -> List[int]:
+        return [
+            i for i in ids if self.match(metadata[i], filters)
+        ]

--- a/utils/retriever/context_retriever.py
+++ b/utils/retriever/context_retriever.py
@@ -1,0 +1,62 @@
+"""High level interface for semantic context retrieval."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from .context_filter import ContextFilter
+from .embedding_encoder import EmbeddingEncoder
+from .index_storage import IndexStorageManager
+from .schema import RetrievalResultItem
+from .vector_indexer import VectorIndexer
+
+
+class ContextRetriever:
+    """Retrieve relevant context units from a vector index."""
+
+    def __init__(
+        self,
+        encoder: EmbeddingEncoder,
+        indexer: VectorIndexer,
+        metadata: List[dict],
+        context_filter: ContextFilter | None = None,
+    ) -> None:
+        self.encoder = encoder
+        self.indexer = indexer
+        self.metadata = metadata
+        self.context_filter = context_filter or ContextFilter()
+
+    @classmethod
+    def from_storage(
+        cls,
+        encoder: EmbeddingEncoder,
+        storage: IndexStorageManager,
+    ) -> "ContextRetriever":
+        indexer, metadata = storage.load()
+        return cls(encoder=encoder, indexer=indexer, metadata=metadata)
+
+    def retrieve(
+        self, query: str, top_k: int = 5, filters: Dict[str, str] | None = None
+    ) -> List[RetrievalResultItem]:
+        query_vec = self.encoder.encode(query)
+        ids, scores = self.indexer.search(query_vec, top_k * 5)
+        results: List[RetrievalResultItem] = []
+        for idx, score in zip(ids, scores):
+            if idx < 0 or idx >= len(self.metadata):
+                continue
+            meta = self.metadata[idx]
+            if filters and not self.context_filter.match(meta, filters):
+                continue
+            results.append(
+                RetrievalResultItem(
+                    query_text=query,
+                    matched_context=meta.get("text", ""),
+                    similarity_score=float(score),
+                    doc_id=meta.get("doc_id"),
+                    context_id=meta.get("context_id"),
+                    section=meta.get("section"),
+                )
+            )
+            if len(results) >= top_k:
+                break
+        return results

--- a/utils/retriever/embedding_encoder.py
+++ b/utils/retriever/embedding_encoder.py
@@ -1,0 +1,50 @@
+"""Text embedding utilities."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+
+
+class EmbeddingEncoder:
+    """Encode text into dense vectors using SentenceTransformers.
+
+    Parameters
+    ----------
+    model_name: str, optional
+        Name of the model to load from ``sentence-transformers``.
+        Defaults to ``"sentence-transformers/all-mpnet-base-v2"``.
+    model: object, optional
+        Preloaded model implementing an ``encode`` method. Primarily useful
+        for testing where a lightweight stub can be supplied.
+    """
+
+    def __init__(
+        self,
+        model_name: str = "sentence-transformers/all-mpnet-base-v2",
+        model: object | None = None,
+    ) -> None:
+        self.model_name = model_name
+        self._model = model
+
+    def _load_model(self) -> None:
+        if self._model is None:
+            from sentence_transformers import SentenceTransformer
+
+            self._model = SentenceTransformer(self.model_name)
+
+    def encode(self, texts: Sequence[str] | str) -> np.ndarray:
+        """Return embeddings for ``texts``.
+
+        Parameters
+        ----------
+        texts:
+            A single string or a sequence of strings to encode.
+        """
+
+        self._load_model()
+        if isinstance(texts, str):
+            texts = [texts]
+        embeddings = self._model.encode(list(texts))
+        return np.asarray(embeddings, dtype="float32")

--- a/utils/retriever/index_storage.py
+++ b/utils/retriever/index_storage.py
@@ -1,0 +1,35 @@
+"""Persistent storage for FAISS index and context metadata."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List, Tuple
+
+from .vector_indexer import VectorIndexer
+
+
+class IndexStorageManager:
+    """Handle saving and loading of vector indices and metadata."""
+
+    def __init__(
+        self, index_path: str | Path, metadata_path: str | Path
+    ) -> None:
+        self.index_path = Path(index_path)
+        self.metadata_path = Path(metadata_path)
+
+    def save(self, indexer: VectorIndexer, metadata: List[dict]) -> None:
+        self.index_path.parent.mkdir(parents=True, exist_ok=True)
+        self.metadata_path.parent.mkdir(parents=True, exist_ok=True)
+        indexer.save(self.index_path)
+        with open(self.metadata_path, "w", encoding="utf-8") as f:
+            json.dump(metadata, f)
+
+    def load(self) -> Tuple[VectorIndexer, List[dict]]:
+        indexer = VectorIndexer.load(self.index_path)
+        if self.metadata_path.exists():
+            with open(self.metadata_path, "r", encoding="utf-8") as f:
+                metadata = json.load(f)
+        else:
+            metadata = []
+        return indexer, metadata

--- a/utils/retriever/schema.py
+++ b/utils/retriever/schema.py
@@ -1,0 +1,14 @@
+"""Pydantic schemas for retrieval results."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class RetrievalResultItem(BaseModel):
+    query_text: str
+    matched_context: str
+    similarity_score: float
+    doc_id: str | None = None
+    context_id: str | None = None
+    section: str | None = None

--- a/utils/retriever/vector_indexer.py
+++ b/utils/retriever/vector_indexer.py
@@ -1,0 +1,48 @@
+"""FAISS vector index abstraction."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import faiss
+import numpy as np
+
+
+class VectorIndexer:
+    """FAISS index wrapper for cosine or inner product search."""
+
+    def __init__(self, dimension: int, metric: str = "cosine") -> None:
+        self.dimension = dimension
+        self.metric = metric
+        if metric not in {"cosine", "ip"}:
+            raise ValueError(
+                "metric must be 'cosine' or 'ip'"
+            )
+        self.index = faiss.IndexFlatIP(dimension)
+
+    def add(self, vectors: np.ndarray) -> None:
+        if vectors.ndim != 2 or vectors.shape[1] != self.dimension:
+            raise ValueError("vectors shape mismatch")
+        if self.metric == "cosine":
+            faiss.normalize_L2(vectors)
+        self.index.add(vectors)
+
+    def search(
+        self, query: np.ndarray, top_k: int
+    ) -> tuple[np.ndarray, np.ndarray]:
+        if query.ndim == 1:
+            query = query[None, :]
+        if self.metric == "cosine":
+            faiss.normalize_L2(query)
+        scores, ids = self.index.search(query, top_k)
+        return ids[0], scores[0]
+
+    def save(self, path: str | Path) -> None:
+        faiss.write_index(self.index, str(path))
+
+    @classmethod
+    def load(cls, path: str | Path, metric: str = "cosine") -> "VectorIndexer":
+        index = faiss.read_index(str(path))
+        obj = cls(index.d, metric=metric)
+        obj.index = index
+        return obj


### PR DESCRIPTION
## Summary
- implement ContextRetriever module with FAISS-based search, embedding encoder, metadata filters, and persistent storage
- expose retrieval utilities in utils.retriever and add comprehensive tests

## Testing
- `flake8 utils/retriever.py utils/retriever tests/test_context_retriever.py`
- `pytest tests/test_context_retriever.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fuzzywuzzy')*

------
https://chatgpt.com/codex/tasks/task_e_688ca35261d4832fa849430495d9d71d