### PR TITLE
Add vector memory builder utility

### DIFF
--- a/tests/test_memory_builder.py
+++ b/tests/test_memory_builder.py
@@ -1,0 +1,56 @@
+import os
+import sys
+import numpy as np
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+)
+
+from utils.retriever import (  # noqa: E402
+    ContextRetriever,
+    EmbeddingEncoder,
+    IndexStorageManager,
+    MemoryBuilder,
+)
+
+
+class DummyModel:
+    def encode(self, texts):
+        vectors = []
+        for t in texts:
+            v = np.zeros(3, dtype="float32")
+            if "cat" in t:
+                v[0] = 1.0
+            if "dog" in t:
+                v[1] = 1.0
+            if "bird" in t:
+                v[2] = 1.0
+            vectors.append(v)
+        return np.vstack(vectors)
+
+
+def test_memory_builder_roundtrip(tmp_path):
+    contexts = [
+        {
+            "text": "The cat sat on the mat.",
+            "doc_id": "d1",
+            "context_id": "c1",
+        },
+        {
+            "text": "Dogs are friendly animals.",
+            "doc_id": "d2",
+            "context_id": "c2",
+        },
+    ]
+    model = DummyModel()
+    encoder = EmbeddingEncoder(model=model)
+    builder = MemoryBuilder(encoder=encoder)
+    indexer, metadata = builder.build(contexts)
+    storage = IndexStorageManager(
+        index_path=tmp_path / "faiss.index",
+        metadata_path=tmp_path / "meta.json",
+    )
+    storage.save(indexer, metadata)
+    retriever = ContextRetriever.from_storage(encoder, storage)
+    results = retriever.retrieve("cat", top_k=1)
+    assert results[0].doc_id == "d1"

--- a/utils/retriever/__init__.py
+++ b/utils/retriever/__init__.py
@@ -6,8 +6,10 @@ try:  # pragma: no cover - optional dependencies
     from .vector_indexer import VectorIndexer
     from .index_storage import IndexStorageManager
     from .context_filter import ContextFilter
+    from .memory_builder import MemoryBuilder
 except Exception:  # pragma: no cover - optional dependencies
-    ContextRetriever = EmbeddingEncoder = VectorIndexer = IndexStorageManager = ContextFilter = None
+    ContextRetriever = EmbeddingEncoder = VectorIndexer = None
+    IndexStorageManager = ContextFilter = MemoryBuilder = None
 
 from .knn_ranker import KNNRanker
 from .penalty_rule import ContextPenaltyRule
@@ -22,6 +24,7 @@ __all__ = [
     "VectorIndexer",
     "IndexStorageManager",
     "ContextFilter",
+    "MemoryBuilder",
     "KNNRanker",
     "ContextPenaltyRule",
     "RankedContextBuilder",

--- a/utils/retriever/memory_builder.py
+++ b/utils/retriever/memory_builder.py
@@ -1,0 +1,67 @@
+"""Utility to build and persist vector-based context memory."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, List, Dict
+
+from .embedding_encoder import EmbeddingEncoder
+from .vector_indexer import VectorIndexer
+from .index_storage import IndexStorageManager
+
+
+class MemoryBuilder:
+    """Build a FAISS index from context units and save with metadata.
+
+    Parameters
+    ----------
+    encoder:
+        Optional pre-initialised :class:`EmbeddingEncoder`. If not provided a
+        default encoder instance will be created lazily when building the
+        memory.
+    metric:
+        Distance metric used by :class:`VectorIndexer`.
+        Defaults to ``"cosine"``.
+    """
+
+    def __init__(
+        self,
+        *,
+        encoder: EmbeddingEncoder | None = None,
+        metric: str = "cosine",
+    ) -> None:
+        self.encoder = encoder or EmbeddingEncoder()
+        self.metric = metric
+
+    def build(
+        self, contexts: Iterable[Dict[str, str]]
+    ) -> tuple[VectorIndexer, List[dict]]:
+        """Return an indexer and metadata list built from ``contexts``."""
+
+        context_list = list(contexts)
+        texts = [c.get("text", "") for c in context_list]
+        vectors = self.encoder.encode(texts)
+        indexer = VectorIndexer(
+            dimension=vectors.shape[1], metric=self.metric
+        )
+        indexer.add(vectors)
+        return indexer, context_list
+
+    def build_from_jsonl(
+        self, path: str | Path
+    ) -> tuple[VectorIndexer, List[dict]]:
+        """Load contexts from ``path`` (JSONL) and build memory."""
+
+        with open(path, "r", encoding="utf-8") as f:
+            contexts = [json.loads(line) for line in f if line.strip()]
+        return self.build(contexts)
+
+    def build_and_save(
+        self,
+        contexts: Iterable[Dict[str, str]],
+        storage: IndexStorageManager,
+    ) -> None:
+        """Build memory from ``contexts`` and persist via ``storage``."""
+
+        indexer, metadata = self.build(contexts)
+        storage.save(indexer, metadata)


### PR DESCRIPTION
## Summary
- add `MemoryBuilder` to construct FAISS indexes and save context metadata
- expose `MemoryBuilder` through retriever package
- test building and retrieval roundtrip with dummy encoder

## Testing
- `flake8 utils/retriever/memory_builder.py utils/retriever/__init__.py tests/test_memory_builder.py`
- `pytest tests/test_context_retriever.py tests/test_knn_ranker.py tests/test_memory_builder.py`

------
https://chatgpt.com/codex/tasks/task_e_688ca7b47034832f8421cf01805cf8b5