### PR TITLE
feat: add kaggle submission writer

### DIFF
--- a/tests/test_kaggle_writer.py
+++ b/tests/test_kaggle_writer.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import json
+import pandas as pd
+import pytest
+
+from utils.submission_writer import KaggleWriter, SubmissionRow
+from utils.llm_inference.output_decoder import FinalPrediction
+
+
+def test_kaggle_writer_creates_csv(tmp_path):
+    fp = FinalPrediction(
+        context_id="PMC1",
+        final_label="Primary",
+        confidence=0.9,
+        raw_output="",
+        used_strategy="",
+        label_source="",
+        logits={},
+    )
+    preds = [fp, {"id": "PMC2", "label": " secondary "}]
+    writer = KaggleWriter()
+    out_csv = tmp_path / "submission.csv"
+    writer.write(preds, out_csv)
+
+    df = pd.read_csv(out_csv)
+    assert list(df.columns) == ["id", "label"]
+    assert df.loc[0, "label"] == "primary"
+    assert df.loc[1, "label"] == "secondary"
+
+
+def test_kaggle_writer_logs_validation_error(tmp_path):
+    preds = [SubmissionRow(id="PMC1", label="invalid")]
+    writer = KaggleWriter()
+    out_csv = tmp_path / "submission.csv"
+    report = tmp_path / "report.jsonl"
+
+    with pytest.raises(ValueError):
+        writer.write(preds, out_csv, report_path=report)
+
+    assert report.exists()
+    lines = report.read_text().strip().splitlines()
+    record = json.loads(lines[0])
+    assert "invalid" in record["error"]

--- a/utils/output_writer.py
+++ b/utils/output_writer.py
@@ -1,6 +1,31 @@
-"""L7: Write predictions into the final submission file."""
+"""L7: Write predictions into the final Kaggle submission file."""
+from __future__ import annotations
+
+from typing import Iterable, Any
+
+from .submission_writer import KaggleWriter
 
 
-def write_submission(rows: list[dict], path: str) -> None:
-    """Placeholder writer that does nothing."""
-    pass
+_writer = KaggleWriter()
+
+
+def write_submission(
+    rows: Iterable[Any], path: str, *, expected_ids: Iterable[str] | None = None, report_path: str | None = None
+) -> None:
+    """Write ``rows`` to ``path`` in the competition's submission format.
+
+    Parameters
+    ----------
+    rows:
+        Iterable of prediction objects or dictionaries containing id/label
+        information.
+    path:
+        Destination CSV file path.
+    expected_ids:
+        Optional iterable of ids that must be present in the submission. Missing
+        ids are filled using the default label.
+    report_path:
+        Optional path to a JSON Lines file where validation issues are written.
+    """
+
+    _writer.write(rows, output_path=path, expected_ids=expected_ids, report_path=report_path)

--- a/utils/submission_writer/__init__.py
+++ b/utils/submission_writer/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for writing Kaggle submission files."""
+from .kaggle_writer import KaggleWriter
+from .schema import SubmissionRow
+
+__all__ = ["KaggleWriter", "SubmissionRow"]

--- a/utils/submission_writer/format_logger.py
+++ b/utils/submission_writer/format_logger.py
@@ -1,0 +1,23 @@
+"""Logging utilities for submission formatting and validation."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+class FormatLogger:
+    """Collect issues encountered during formatting/validation."""
+
+    def __init__(self) -> None:
+        self.issues: List[Dict[str, Any]] = []
+
+    def log(self, **info: Any) -> None:
+        self.issues.append(info)
+
+    def write_report(self, path: str) -> None:
+        file_path = Path(path)
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        with file_path.open("w", encoding="utf-8") as fh:
+            for issue in self.issues:
+                fh.write(json.dumps(issue) + "\n")

--- a/utils/submission_writer/kaggle_writer.py
+++ b/utils/submission_writer/kaggle_writer.py
@@ -1,0 +1,73 @@
+"""High-level writer producing Kaggle ``submission.csv`` files."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Any
+
+import pandas as pd
+
+from .submission_formatter import SubmissionFormatter
+from .schema_validator import SchemaValidator
+from .missing_handler import MissingEntryHandler
+from .format_logger import FormatLogger
+
+
+class KaggleWriter:
+    """Convert predictions into a validated Kaggle submission file."""
+
+    def __init__(
+        self,
+        formatter: SubmissionFormatter | None = None,
+        validator: SchemaValidator | None = None,
+        missing_handler: MissingEntryHandler | None = None,
+        logger: FormatLogger | None = None,
+    ) -> None:
+        self.formatter = formatter or SubmissionFormatter()
+        self.validator = validator or SchemaValidator()
+        self.missing_handler = missing_handler or MissingEntryHandler()
+        self.logger = logger or FormatLogger()
+
+    def write(
+        self,
+        predictions: Iterable[Any],
+        output_path: str,
+        expected_ids: Iterable[str] | None = None,
+        report_path: str | None = None,
+    ) -> pd.DataFrame:
+        """Write ``predictions`` to ``output_path``.
+
+        Parameters
+        ----------
+        predictions:
+            Iterable of prediction objects or dicts containing id/label info.
+        output_path:
+            Target CSV path.
+        expected_ids:
+            Optional list of ids that must be present in the final file. Missing
+            ids are filled with ``default_label`` in :class:`MissingEntryHandler`.
+        report_path:
+            If provided, issues encountered are written as JSONL to this path.
+        """
+
+        rows = self.formatter.format(predictions)
+        rows = self.missing_handler.handle(rows, expected_ids)
+
+        try:
+            self.validator.validate(rows)
+        except ValueError as exc:  # pragma: no cover - validation errors are rare
+            self.logger.log(error=str(exc))
+            if report_path:
+                self.logger.write_report(report_path)
+            raise
+
+        data = [{"id": r.id, "label": r.label} for r in rows]
+        df = pd.DataFrame(data, columns=["id", "label"])
+
+        path = Path(output_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        df.to_csv(path, index=False)
+
+        if report_path and self.logger.issues:
+            self.logger.write_report(report_path)
+
+        return df

--- a/utils/submission_writer/missing_handler.py
+++ b/utils/submission_writer/missing_handler.py
@@ -1,0 +1,24 @@
+"""Utilities for handling missing submission entries."""
+from __future__ import annotations
+
+from typing import Iterable, List, Optional
+
+from .schema import SubmissionRow
+
+
+class MissingEntryHandler:
+    """Fill in missing IDs with a default label."""
+
+    def handle(
+        self,
+        rows: List[SubmissionRow],
+        expected_ids: Optional[Iterable[str]] = None,
+        default_label: str = "none",
+    ) -> List[SubmissionRow]:
+        if not expected_ids:
+            return rows
+        existing = {row.id for row in rows}
+        for expected in expected_ids:
+            if expected not in existing:
+                rows.append(SubmissionRow(id=str(expected), label=default_label))
+        return rows

--- a/utils/submission_writer/schema.py
+++ b/utils/submission_writer/schema.py
@@ -1,0 +1,10 @@
+"""Schema definitions for Kaggle submission rows."""
+from dataclasses import dataclass
+
+
+@dataclass
+class SubmissionRow:
+    """Single row in the final submission file."""
+
+    id: str
+    label: str

--- a/utils/submission_writer/schema_validator.py
+++ b/utils/submission_writer/schema_validator.py
@@ -1,0 +1,19 @@
+"""Validate submission rows against competition rules."""
+from __future__ import annotations
+
+from typing import Iterable
+
+from .schema import SubmissionRow
+
+
+class SchemaValidator:
+    """Ensure rows follow ``id``/``label`` schema and allowed values."""
+
+    allowed_labels = {"primary", "secondary", "none"}
+
+    def validate(self, rows: Iterable[SubmissionRow]) -> None:
+        for idx, row in enumerate(rows):
+            if not row.id:
+                raise ValueError(f"Row {idx} has empty id")
+            if row.label not in self.allowed_labels:
+                raise ValueError(f"Row {idx} has invalid label {row.label}")

--- a/utils/submission_writer/submission_formatter.py
+++ b/utils/submission_writer/submission_formatter.py
@@ -1,0 +1,34 @@
+"""Convert various prediction structures into :class:`SubmissionRow`."""
+from __future__ import annotations
+
+from typing import Iterable, Any, List
+
+from .schema import SubmissionRow
+
+
+class SubmissionFormatter:
+    """Format raw predictions into ``SubmissionRow`` items."""
+
+    def format(self, predictions: Iterable[Any]) -> List[SubmissionRow]:
+        rows: List[SubmissionRow] = []
+        for pred in predictions:
+            row_id: str | None = None
+            label: str | None = None
+
+            if isinstance(pred, SubmissionRow):
+                row_id = pred.id
+                label = pred.label
+            elif hasattr(pred, "context_id") and hasattr(pred, "final_label"):
+                row_id = getattr(pred, "context_id")
+                label = getattr(pred, "final_label")
+            elif isinstance(pred, dict):
+                row_id = pred.get("id") or pred.get("context_id")
+                label = pred.get("label") or pred.get("final_label")
+
+            if row_id is None or label is None:
+                continue
+
+            rows.append(
+                SubmissionRow(id=str(row_id).strip(), label=str(label).strip().lower())
+            )
+        return rows


### PR DESCRIPTION
## Summary
- add modular KaggleWriter to format and validate predictions into submission.csv
- integrate KaggleWriter into output_writer
- cover writer with tests and validation logging

## Testing
- `ruff check utils/submission_writer utils/output_writer.py tests/test_kaggle_writer.py`
- `pytest` *(fails: TypeError: 'NoneType' object is not callable in context retrieval tests)*

------
https://chatgpt.com/codex/tasks/task_e_688cccd31014832fae4ff1e90baec6ae