### PR TITLE
Add comprehensive CSV schema validator

### DIFF
--- a/tests/test_csv_schema_validator.py
+++ b/tests/test_csv_schema_validator.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+import pandas as pd
+
+from utils.submission_writer import CSVSchemaValidator
+
+
+def _write_csv(tmp_path, rows):
+    path = tmp_path / "submission.csv"
+    pd.DataFrame(rows).to_csv(path, index=False)
+    return path
+
+
+def test_validator_passes_valid_file(tmp_path):
+    csv_path = _write_csv(tmp_path, [{"id": "A", "label": "primary"}])
+    validator = CSVSchemaValidator()
+    report = validator.validate(csv_path)
+    assert report.summary["errors"] == 0
+    assert report.summary["valid_rows"] == 1
+
+
+def test_validator_reports_issue_and_writes_report(tmp_path):
+    csv_path = _write_csv(
+        tmp_path,
+        [
+            {"id": "A", "label": "primary"},
+            {"id": "A", "label": "invalid"},
+        ],
+    )
+    validator = CSVSchemaValidator()
+    report_path = tmp_path / "report.jsonl"
+    report = validator.validate(csv_path, report_path=report_path)
+    assert report.summary["errors"] == 2
+    assert report.summary["error_types"]["duplicate_id"] == 1
+    assert report.summary["error_types"]["invalid_label_value"] == 1
+    data = json.loads(report_path.read_text())
+    assert data["summary"]["errors"] == 2

--- a/utils/submission_writer/__init__.py
+++ b/utils/submission_writer/__init__.py
@@ -1,5 +1,12 @@
 """Utilities for writing Kaggle submission files."""
 from .kaggle_writer import KaggleWriter
-from .schema import SubmissionRow
+from .schema import SubmissionRow, ValidationIssue, ValidationReport
+from .csv_schema_validator import CSVSchemaValidator
 
-__all__ = ["KaggleWriter", "SubmissionRow"]
+__all__ = [
+    "KaggleWriter",
+    "SubmissionRow",
+    "ValidationIssue",
+    "ValidationReport",
+    "CSVSchemaValidator",
+]

--- a/utils/submission_writer/column_checker.py
+++ b/utils/submission_writer/column_checker.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+"""Column structure validation for submission files."""
+from typing import Sequence, Tuple
+
+
+class ColumnStructureChecker:
+    """Ensure required columns exist in the expected order."""
+
+    def __init__(self, expected: Sequence[str]) -> None:
+        self.expected = list(expected)
+
+    def check(self, columns: Sequence[str]) -> Tuple[bool, str | None]:
+        cols = list(columns)
+        if cols != self.expected:
+            return False, f"Expected columns {self.expected} but found {cols}"
+        return True, None

--- a/utils/submission_writer/csv_schema_validator.py
+++ b/utils/submission_writer/csv_schema_validator.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+"""Validate ``submission.csv`` files for structural integrity."""
+from pathlib import Path
+from typing import Iterable, Dict
+
+import pandas as pd
+
+from .column_checker import ColumnStructureChecker
+from .row_value_validator import RowValueValidator
+from .validator_logger import SchemaValidatorLogger
+from .schema import ValidationIssue, ValidationReport
+
+
+class CSVSchemaValidator:
+    """Run a suite of checks against a CSV submission file."""
+
+    def __init__(
+        self,
+        expected_columns: Iterable[str] | None = None,
+        allowed_labels: Iterable[str] | None = None,
+        logger: SchemaValidatorLogger | None = None,
+    ) -> None:
+        self.expected_columns = list(expected_columns or ["id", "label"])
+        self.allowed_labels = list(
+            allowed_labels or ["primary", "secondary", "none"]
+        )
+        self.logger = logger or SchemaValidatorLogger()
+        self._column_checker = ColumnStructureChecker(self.expected_columns)
+        self._row_validator = RowValueValidator(self.allowed_labels)
+
+    def validate(
+        self, csv_path: str | Path, report_path: str | None = None
+    ) -> ValidationReport:
+        """Validate ``csv_path`` and optionally write a JSON report."""
+        path = Path(csv_path)
+        df = pd.read_csv(path)
+        issues: list[ValidationIssue] = []
+        error_types: Dict[str, int] = {}
+
+        ok, msg = self._column_checker.check(df.columns)
+        if not ok:
+            issue = ValidationIssue(
+                row_index=None,
+                id=None,
+                error_type="column_mismatch",
+                detail=msg or "",
+            )
+            self.logger.log_issue(issue)
+            issues.append(issue)
+            error_types[issue.error_type] = (
+                error_types.get(issue.error_type, 0) + 1
+            )
+
+        for idx, row in df.iterrows():
+            for issue in self._row_validator.validate(idx, row):
+                issues.append(issue)
+                self.logger.log_issue(issue)
+                error_types[issue.error_type] = (
+                    error_types.get(issue.error_type, 0) + 1
+                )
+
+        error_rows = len(
+            {i.row_index for i in issues if i.row_index is not None}
+        )
+        summary = {
+            "total_rows": int(len(df)),
+            "valid_rows": int(len(df) - error_rows),
+            "errors": int(len(issues)),
+            "error_types": error_types,
+        }
+        report = ValidationReport(
+            file=path.name, summary=summary, issues=issues
+        )
+
+        if report_path:
+            self.logger.write_report(report, report_path)
+
+        return report

--- a/utils/submission_writer/missing_detector.py
+++ b/utils/submission_writer/missing_detector.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+"""Detect missing fields in submission rows."""
+from typing import List
+import pandas as pd
+
+from .schema import ValidationIssue
+
+
+class MissingEntryDetector:
+    """Identify empty ``id`` or ``label`` fields."""
+
+    def check(self, row_index: int, row: pd.Series) -> List[ValidationIssue]:
+        issues: List[ValidationIssue] = []
+        row_id = row.get("id")
+        label = row.get("label")
+        if pd.isna(row_id) or row_id == "":
+            issues.append(
+                ValidationIssue(
+                    row_index=row_index,
+                    id=None,
+                    error_type="missing_id",
+                    detail="Empty id",
+                )
+            )
+        if pd.isna(label) or label == "":
+            issues.append(
+                ValidationIssue(
+                    row_index=row_index,
+                    id=row_id if not pd.isna(row_id) else None,
+                    error_type="missing_label",
+                    detail="Label is missing",
+                )
+            )
+        return issues

--- a/utils/submission_writer/row_value_validator.py
+++ b/utils/submission_writer/row_value_validator.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+"""Validate individual submission row values."""
+from typing import Iterable, List
+import pandas as pd
+
+from .schema import ValidationIssue
+from .missing_detector import MissingEntryDetector
+from .uniqueness_checker import UniquenessChecker
+
+
+class RowValueValidator:
+    """Check ``id``/``label`` values for each row."""
+
+    def __init__(self, allowed_labels: Iterable[str]) -> None:
+        self.allowed = {str(lbl).lower() for lbl in allowed_labels}
+        self._missing = MissingEntryDetector()
+        self._uniq = UniquenessChecker()
+
+    def validate(
+        self, row_index: int, row: pd.Series
+    ) -> List[ValidationIssue]:
+        issues = self._missing.check(row_index, row)
+
+        if not any(issue.error_type == "missing_label" for issue in issues):
+            label = str(row.get("label")).strip().lower()
+            if label not in self.allowed:
+                allowed = sorted(self.allowed)
+                issues.append(
+                    ValidationIssue(
+                        row_index=row_index,
+                        id=row.get("id"),
+                        error_type="invalid_label_value",
+                        detail=(
+                            "Label '{label}' is not one of {allowed}".format(
+                                label=row.get("label"),
+                                allowed=allowed,
+                            )
+                        ),
+                    )
+                )
+
+        if not any(issue.error_type == "missing_id" for issue in issues):
+            dup = self._uniq.check(row_index, str(row.get("id")))
+            if dup:
+                issues.append(dup)
+
+        return issues

--- a/utils/submission_writer/schema.py
+++ b/utils/submission_writer/schema.py
@@ -1,5 +1,8 @@
-"""Schema definitions for Kaggle submission rows."""
-from dataclasses import dataclass
+"""Schema definitions for Kaggle submission rows and validation reports."""
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from typing import Any, Dict, List, Optional
 
 
 @dataclass
@@ -8,3 +11,32 @@ class SubmissionRow:
 
     id: str
     label: str
+
+
+@dataclass
+class ValidationIssue:
+    """A single validation problem discovered in ``submission.csv``."""
+
+    row_index: Optional[int]
+    id: Optional[str]
+    error_type: str
+    detail: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class ValidationReport:
+    """Summary of validation results for a submission file."""
+
+    file: str
+    summary: Dict[str, Any]
+    issues: List[ValidationIssue]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "file": self.file,
+            "summary": self.summary,
+            "issues": [issue.to_dict() for issue in self.issues],
+        }

--- a/utils/submission_writer/uniqueness_checker.py
+++ b/utils/submission_writer/uniqueness_checker.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+"""Detect duplicate identifiers in submission rows."""
+from typing import Optional
+
+from .schema import ValidationIssue
+
+
+class UniquenessChecker:
+    """Track seen ids and flag duplicates."""
+
+    def __init__(self) -> None:
+        self._seen: set[str] = set()
+
+    def check(self, row_index: int, row_id: str) -> Optional[ValidationIssue]:
+        if row_id in self._seen:
+            return ValidationIssue(
+                row_index=row_index,
+                id=row_id,
+                error_type="duplicate_id",
+                detail=f"Duplicate id {row_id}",
+            )
+        self._seen.add(row_id)
+        return None

--- a/utils/submission_writer/validator_logger.py
+++ b/utils/submission_writer/validator_logger.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+"""Logging utilities for :class:`CSVSchemaValidator`."""
+import json
+from pathlib import Path
+from typing import List
+
+from .schema import ValidationIssue, ValidationReport
+
+
+class SchemaValidatorLogger:
+    """Collect and persist validation issues."""
+
+    def __init__(self) -> None:
+        self.issues: List[ValidationIssue] = []
+
+    def log_issue(self, issue: ValidationIssue) -> None:
+        self.issues.append(issue)
+
+    def write_report(self, report: ValidationReport, path: str) -> None:
+        file_path = Path(path)
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        with file_path.open("w", encoding="utf-8") as fh:
+            json.dump(report.to_dict(), fh)
+            fh.write("\n")


### PR DESCRIPTION
## Summary
- add CSVSchemaValidator with column, value and uniqueness checks
- expand schema definitions with ValidationIssue and ValidationReport
- test validator and update submission_writer exports

## Testing
- `flake8 utils/submission_writer/csv_schema_validator.py utils/submission_writer/row_value_validator.py utils/submission_writer/column_checker.py utils/submission_writer/uniqueness_checker.py utils/submission_writer/missing_detector.py utils/submission_writer/validator_logger.py utils/submission_writer/__init__.py utils/submission_writer/schema.py tests/test_csv_schema_validator.py`
- `PYTHONPATH=. pytest tests/test_csv_schema_validator.py tests/test_kaggle_writer.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_688cd2a87348832f9e18800e206f5f76