### PR TITLE
Add submission generator with CSV validation

### DIFF
--- a/tests/test_output_writer.py
+++ b/tests/test_output_writer.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+import pandas as pd
+import pytest
+
+from utils.output_writer import generate_submission
+
+
+def _write_jsonl(path, rows):
+    with open(path, "w", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(json.dumps(row) + "\n")
+
+
+def test_generate_submission_creates_csv_and_report(tmp_path):
+    pred_file = tmp_path / "pred.jsonl"
+    _write_jsonl(
+        pred_file,
+        [
+            {"id": "A", "label": "primary"},
+            {"id": "B", "label": "secondary"},
+        ],
+    )
+    out_csv = tmp_path / "submission.csv"
+    report = tmp_path / "report.jsonl"
+
+    generate_submission(pred_file, out_csv, report_path=report)
+
+    df = pd.read_csv(out_csv)
+    assert list(df.columns) == ["id", "label"]
+    assert df.loc[0, "label"] == "primary"
+    assert df.loc[1, "label"] == "secondary"
+
+    lines = report.read_text().strip().splitlines()
+    summary = json.loads(lines[-1])
+    assert summary["summary"]["errors"] == 0
+
+
+def test_generate_submission_raises_on_validation_error(tmp_path):
+    pred_file = tmp_path / "pred.jsonl"
+    _write_jsonl(
+        pred_file,
+        [
+            {"id": "A", "label": "primary"},
+            {"id": "A", "label": "secondary"},
+        ],
+    )
+    out_csv = tmp_path / "submission.csv"
+    report = tmp_path / "report.jsonl"
+
+    with pytest.raises(ValueError):
+        generate_submission(pred_file, out_csv, report_path=report)
+
+    summary = json.loads(report.read_text().strip().splitlines()[-1])
+    assert summary["summary"]["errors"] > 0

--- a/utils/output_writer.py
+++ b/utils/output_writer.py
@@ -1,31 +1,65 @@
 """L7: Write predictions into the final Kaggle submission file."""
 from __future__ import annotations
 
-from typing import Iterable, Any
+import json
+from pathlib import Path
+from typing import Iterable, Any, List
 
-from .submission_writer import KaggleWriter
+from .submission_writer import KaggleWriter, CSVSchemaValidator
 
 
 _writer = KaggleWriter()
+_validator = CSVSchemaValidator()
 
 
 def write_submission(
-    rows: Iterable[Any], path: str, *, expected_ids: Iterable[str] | None = None, report_path: str | None = None
+    rows: Iterable[Any],
+    path: str,
+    *,
+    expected_ids: Iterable[str] | None = None,
+    report_path: str | None = None,
 ) -> None:
-    """Write ``rows`` to ``path`` in the competition's submission format.
+    """Write ``rows`` to ``path`` in the competition's submission format."""
 
-    Parameters
-    ----------
-    rows:
-        Iterable of prediction objects or dictionaries containing id/label
-        information.
-    path:
-        Destination CSV file path.
-    expected_ids:
-        Optional iterable of ids that must be present in the submission. Missing
-        ids are filled using the default label.
-    report_path:
-        Optional path to a JSON Lines file where validation issues are written.
+    _writer.write(
+        rows,
+        output_path=path,
+        expected_ids=expected_ids,
+        report_path=report_path,
+    )
+
+
+def generate_submission(
+    predictions_path: str | Path,
+    output_path: str | Path,
+    *,
+    expected_ids: Iterable[str] | None = None,
+    report_path: str | None = None,
+) -> None:
+    """Read predictions from ``predictions_path`` and create a submission.
+
+    The resulting CSV is validated using :class:`CSVSchemaValidator`. If
+    validation issues are found a :class:`ValueError` is raised.
     """
 
-    _writer.write(rows, output_path=path, expected_ids=expected_ids, report_path=report_path)
+    path = Path(predictions_path)
+    with path.open("r", encoding="utf-8") as fh:
+        predictions: List[Any] = [json.loads(line) for line in fh if line.strip()]
+
+    write_submission(
+        predictions,
+        str(output_path),
+        expected_ids=expected_ids,
+        report_path=report_path,
+    )
+
+    report = _validator.validate(output_path)
+
+    if report_path:
+        report_file = Path(report_path)
+        report_file.parent.mkdir(parents=True, exist_ok=True)
+        with report_file.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(report.to_dict()) + "\n")
+
+    if report.summary.get("errors", 0) > 0:
+        raise ValueError("submission validation failed")


### PR DESCRIPTION
## Summary
- add generate_submission to orchestrate writing predictions and validating output CSV
- append validation report and surface errors for malformed submissions
- test submission creation and validation failure on duplicate IDs

## Testing
- `ruff check utils/output_writer.py tests/test_output_writer.py`
- `PYTHONPATH=. pytest tests/test_kaggle_writer.py tests/test_csv_schema_validator.py tests/test_output_writer.py`


------
https://chatgpt.com/codex/tasks/task_e_688cd5b0d778832fba5ec958be8b89a6